### PR TITLE
ElasticClient should be shared across object instances

### DIFF
--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -6,12 +6,16 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
+using Nest;
 
 namespace osu.ElasticIndexer
 {
     public class AppSettings
     {
         public static readonly IImmutableList<string> VALID_MODES = ImmutableList.Create("osu", "mania", "taiko", "fruits");
+
+        // shared client without a default index.
+        internal static readonly ElasticClient ElasticClient;
 
         private static readonly IConfigurationRoot config;
 
@@ -54,6 +58,8 @@ namespace osu.ElasticIndexer
 
             ElasticsearchHost = config["elasticsearch:host"];
             ElasticsearchPrefix = config["elasticsearch:prefix"];
+
+            ElasticClient = new ElasticClient(new ConnectionSettings(new Uri(ElasticsearchHost)));
         }
 
         // same value as elasticsearch-net

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -15,7 +15,7 @@ namespace osu.ElasticIndexer
         public static readonly IImmutableList<string> VALID_MODES = ImmutableList.Create("osu", "mania", "taiko", "fruits");
 
         // shared client without a default index.
-        internal static readonly ElasticClient ElasticClient;
+        internal static readonly ElasticClient ELASTIC_CLIENT;
 
         private static readonly IConfigurationRoot config;
 
@@ -59,7 +59,7 @@ namespace osu.ElasticIndexer
             ElasticsearchHost = config["elasticsearch:host"];
             ElasticsearchPrefix = config["elasticsearch:prefix"];
 
-            ElasticClient = new ElasticClient(new ConnectionSettings(new Uri(ElasticsearchHost)));
+            ELASTIC_CLIENT = new ElasticClient(new ConnectionSettings(new Uri(ElasticsearchHost)));
         }
 
         // same value as elasticsearch-net

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -13,7 +13,7 @@ namespace osu.ElasticIndexer
     internal class BulkIndexingDispatcher<T> where T : Model
     {
         // ElasticClient is thread-safe and should be shared per host.
-        private readonly ElasticClient elasticClient = new ElasticClient(new ConnectionSettings(new Uri(AppSettings.ElasticsearchHost)));
+        private static readonly ElasticClient elasticClient = new ElasticClient(new ConnectionSettings(new Uri(AppSettings.ElasticsearchHost)));
 
         // Self-limiting read-ahead buffer to ensure
         // there is always data ready to be dispatched to Elasticsearch.

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -12,6 +12,9 @@ namespace osu.ElasticIndexer
 {
     internal class BulkIndexingDispatcher<T> where T : Model
     {
+        // use shared instance to avoid socket leakage.
+        private readonly ElasticClient elasticClient = AppSettings.ELASTIC_CLIENT;
+
         // Self-limiting read-ahead buffer to ensure
         // there is always data ready to be dispatched to Elasticsearch.
         private readonly BlockingCollection<List<T>> readBuffer = new BlockingCollection<List<T>>(AppSettings.BufferSize);
@@ -49,7 +52,7 @@ namespace osu.ElasticIndexer
                 while (true)
                 {
                     var bulkDescriptor = new BulkDescriptor().Index(index).IndexMany(chunk);
-                    var response = AppSettings.ELASTIC_CLIENT.Bulk(bulkDescriptor);
+                    var response = elasticClient.Bulk(bulkDescriptor);
 
                     bool retry;
                     (success, retry) = retryOnResponse(response, chunk);

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -49,7 +49,7 @@ namespace osu.ElasticIndexer
                 while (true)
                 {
                     var bulkDescriptor = new BulkDescriptor().Index(index).IndexMany(chunk);
-                    var response = AppSettings.ElasticClient.Bulk(bulkDescriptor);
+                    var response = AppSettings.ELASTIC_CLIENT.Bulk(bulkDescriptor);
 
                     bool retry;
                     (success, retry) = retryOnResponse(response, chunk);

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -12,9 +12,6 @@ namespace osu.ElasticIndexer
 {
     internal class BulkIndexingDispatcher<T> where T : Model
     {
-        // ElasticClient is thread-safe and should be shared per host.
-        private static readonly ElasticClient elasticClient = new ElasticClient(new ConnectionSettings(new Uri(AppSettings.ElasticsearchHost)));
-
         // Self-limiting read-ahead buffer to ensure
         // there is always data ready to be dispatched to Elasticsearch.
         private readonly BlockingCollection<List<T>> readBuffer = new BlockingCollection<List<T>>(AppSettings.BufferSize);
@@ -52,7 +49,7 @@ namespace osu.ElasticIndexer
                 while (true)
                 {
                     var bulkDescriptor = new BulkDescriptor().Index(index).IndexMany(chunk);
-                    var response = elasticClient.Bulk(bulkDescriptor);
+                    var response = AppSettings.ElasticClient.Bulk(bulkDescriptor);
 
                     bool retry;
                     (success, retry) = retryOnResponse(response, chunk);

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -19,7 +19,7 @@ namespace osu.ElasticIndexer
         public long? ResumeFrom { get; set; }
         public string Suffix { get; set; }
 
-        private readonly ElasticClient elasticClient = new ElasticClient(new ConnectionSettings(new Uri(AppSettings.ElasticsearchHost)));
+        private static readonly ElasticClient elasticClient = new ElasticClient(new ConnectionSettings(new Uri(AppSettings.ElasticsearchHost)));
 
         private BulkIndexingDispatcher<T> dispatcher;
 

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -119,7 +119,7 @@ namespace osu.ElasticIndexer
             Console.WriteLine();
             Console.WriteLine($"Find or create index for `{name}`...");
             var metas = IndexMeta.GetByAlias(name).ToList();
-            var aliasedIndices = AppSettings.ElasticClient.GetIndicesPointingToAlias(name);
+            var aliasedIndices = AppSettings.ELASTIC_CLIENT.GetIndicesPointingToAlias(name);
             string index;
 
             if (!AppSettings.IsNew)
@@ -152,7 +152,7 @@ namespace osu.ElasticIndexer
             // create by supplying the json file instead of the attributed class because we're not
             // mapping every field but still want everything for _source.
             var json = File.ReadAllText(Path.GetFullPath("schemas/high_scores.json"));
-            AppSettings.ElasticClient.LowLevel.IndicesCreate<DynamicResponse>(index, json);
+            AppSettings.ELASTIC_CLIENT.LowLevel.IndicesCreate<DynamicResponse>(index, json);
 
             return index;
 
@@ -164,21 +164,21 @@ namespace osu.ElasticIndexer
             Console.WriteLine($"Updating `{alias}` alias to `{index}`...");
 
             var aliasDescriptor = new BulkAliasDescriptor();
-            var oldIndices = AppSettings.ElasticClient.GetIndicesPointingToAlias(alias);
+            var oldIndices = AppSettings.ELASTIC_CLIENT.GetIndicesPointingToAlias(alias);
 
             foreach (var oldIndex in oldIndices)
                 aliasDescriptor.Remove(d => d.Alias(alias).Index(oldIndex));
 
             aliasDescriptor.Add(d => d.Alias(alias).Index(index));
 
-            Console.WriteLine(AppSettings.ElasticClient.Alias(aliasDescriptor));
+            Console.WriteLine(AppSettings.ELASTIC_CLIENT.Alias(aliasDescriptor));
 
             // cleanup
             if (!close) return;
             foreach (var toClose in oldIndices.Where(x => x != index))
             {
                 Console.WriteLine($"Closing {toClose}");
-                AppSettings.ElasticClient.CloseIndex(toClose);
+                AppSettings.ELASTIC_CLIENT.CloseIndex(toClose);
             }
         }
     }


### PR DESCRIPTION
otherwise sockets get leaked on Linux.

before
```
netstat -apn | grep dotnet | wc -l
115
netstat -apn | grep dotnet | wc -l
121
netstat -apn | grep dotnet | wc -l
123
```

after
```
netstat -apn | grep dotnet | wc -l
7
netstat -apn | grep dotnet | wc -l
7
netstat -apn | grep dotnet | wc -l
7
```

Updating to Nest 6.2 which targets netcore2.1 does not fix this.
