### PR TITLE
Fix schemas not being included in the output directory

### DIFF
--- a/osu.ElasticIndexer/osu.ElasticIndexer.csproj
+++ b/osu.ElasticIndexer/osu.ElasticIndexer.csproj
@@ -19,5 +19,8 @@
     <None Update="appsettings.*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="schemas/**/*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves "Could not find a part of the path 'schemas/high_scores.json'" errors.