### PR TITLE
Wait on correct db state if docker environment variable is present

### DIFF
--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -60,6 +60,8 @@ namespace osu.ElasticIndexer
             ElasticsearchPrefix = config["elasticsearch:prefix"];
 
             ELASTIC_CLIENT = new ElasticClient(new ConnectionSettings(new Uri(ElasticsearchHost)));
+
+            UseDocker = Environment.GetEnvironmentVariable("DOCKER")?.Contains("1") ?? false;
         }
 
         // same value as elasticsearch-net
@@ -88,6 +90,8 @@ namespace osu.ElasticIndexer
         public static int BufferSize { get; private set; } = 5;
 
         public static long? ResumeFrom { get; private set; }
+
+        public static bool UseDocker { get; private set; }
 
         private static bool parseBool(string key)
         {

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.Threading;
 using Dapper;
+using MySql.Data.MySqlClient;
 
 namespace osu.ElasticIndexer
 {
@@ -12,6 +13,28 @@ namespace osu.ElasticIndexer
     {
         public static void Main()
         {
+            if (AppSettings.UseDocker)
+            {
+                Console.WriteLine("Waiting for database...");
+
+                while (true)
+                {
+                    try
+                    {
+                        using (var conn = new MySqlConnection(AppSettings.ConnectionString))
+                        {
+                            if (conn.QuerySingle<int>("SELECT `count` FROM `osu_counts` WHERE `name` = 'docker_db_step'") >= 3)
+                                break;
+                        }
+                    }
+                    catch
+                    {
+                    }
+
+                    Thread.Sleep(1000);
+                }
+            }
+
             DefaultTypeMap.MatchNamesWithUnderscores = true;
             IndexMeta.CreateIndex();
 
@@ -21,6 +44,18 @@ namespace osu.ElasticIndexer
             {
                 // do a single run
                 runIndexing(AppSettings.ResumeFrom);
+            }
+
+            if (AppSettings.UseDocker)
+            {
+                using (var conn = new MySqlConnection(AppSettings.ConnectionString))
+                {
+                    conn.Execute("INSERT INTO `osu_counts` (`name`, `count`) VALUES (@Name, @Count) ON DUPLICATE KEY UPDATE `count` = @Count", new
+                    {
+                        Name = "docker_db_step",
+                        Count = 4
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
Not a super biggie but right now I have to manually `docker-compose up -d esindexer` after all the scores have been recalculated. This removes that step.