### PR TITLE
Add support for reading from score processing queue

### DIFF
--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -52,8 +52,8 @@ namespace osu.ElasticIndexer
             Modes = modesStr.Split(',', StringSplitOptions.RemoveEmptyEntries).Intersect(VALID_MODES).ToImmutableArray();
 
             ConnectionString = config.GetConnectionString("osu");
-            IsCrawler = parseBool("crawl");
             IsNew = parseBool("new");
+            IsUsingQueue = !parseBool("crawl");
             IsWatching = parseBool("watch");
             Prefix = config["elasticsearch:prefix"];
 
@@ -78,9 +78,9 @@ namespace osu.ElasticIndexer
 
         public static string ElasticsearchPrefix { get; private set; }
 
-        public static bool IsCrawler { get; private set; }
-
         public static bool IsNew { get; private set; }
+
+        public static bool IsUsingQueue { get; private set; }
 
         public static bool IsWatching { get; private set; }
 

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -52,6 +52,7 @@ namespace osu.ElasticIndexer
             Modes = modesStr.Split(',', StringSplitOptions.RemoveEmptyEntries).Intersect(VALID_MODES).ToImmutableArray();
 
             ConnectionString = config.GetConnectionString("osu");
+            IsCrawler = parseBool("crawl");
             IsNew = parseBool("new");
             IsWatching = parseBool("watch");
             Prefix = config["elasticsearch:prefix"];
@@ -76,6 +77,8 @@ namespace osu.ElasticIndexer
         public static string ElasticsearchHost { get; private set; }
 
         public static string ElasticsearchPrefix { get; private set; }
+
+        public static bool IsCrawler { get; private set; }
 
         public static bool IsNew { get; private set; }
 

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -62,7 +62,7 @@ namespace osu.ElasticIndexer
                     Task.Delay(AppSettings.BulkAllBackOffTimeDefault).Wait();
                 }
 
-                if (success && AppSettings.IsCrawler)
+                if (success && !AppSettings.IsUsingQueue)
                 {
                     // TODO: should probably aggregate responses and update to highest successful.
                     IndexMeta.UpdateAsync(new IndexMeta

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -20,11 +20,13 @@ namespace osu.ElasticIndexer
         private readonly BlockingCollection<List<T>> readBuffer = new BlockingCollection<List<T>>(AppSettings.BufferSize);
 
         private readonly string alias;
+        private readonly bool isCrawler;
         private readonly string index;
 
-        internal BulkIndexingDispatcher(string alias, string index)
+        internal BulkIndexingDispatcher(string alias, string index, bool isCrawler)
         {
             this.alias = alias;
+            this.isCrawler = isCrawler;
             this.index = index;
         }
 
@@ -62,7 +64,7 @@ namespace osu.ElasticIndexer
                     Task.Delay(AppSettings.BulkAllBackOffTimeDefault).Wait();
                 }
 
-                if (success)
+                if (success && isCrawler)
                 {
                     // TODO: should probably aggregate responses and update to highest successful.
                     IndexMeta.UpdateAsync(new IndexMeta

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -20,13 +20,11 @@ namespace osu.ElasticIndexer
         private readonly BlockingCollection<List<T>> readBuffer = new BlockingCollection<List<T>>(AppSettings.BufferSize);
 
         private readonly string alias;
-        private readonly bool isCrawler;
         private readonly string index;
 
-        internal BulkIndexingDispatcher(string alias, string index, bool isCrawler)
+        internal BulkIndexingDispatcher(string alias, string index)
         {
             this.alias = alias;
-            this.isCrawler = isCrawler;
             this.index = index;
         }
 
@@ -64,7 +62,7 @@ namespace osu.ElasticIndexer
                     Task.Delay(AppSettings.BulkAllBackOffTimeDefault).Wait();
                 }
 
-                if (success && isCrawler)
+                if (success && AppSettings.IsCrawler)
                 {
                     // TODO: should probably aggregate responses and update to highest successful.
                     IndexMeta.UpdateAsync(new IndexMeta

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -10,7 +10,7 @@ using Nest;
 
 namespace osu.ElasticIndexer
 {
-    internal class BulkIndexingDispatcher<T> where T : Model
+    internal class BulkIndexingDispatcher<T> where T : HighScore
     {
         // use shared instance to avoid socket leakage.
         private readonly ElasticClient elasticClient = AppSettings.ELASTIC_CLIENT;

--- a/osu.ElasticIndexer/HighScoreFruits.cs
+++ b/osu.ElasticIndexer/HighScoreFruits.cs
@@ -5,6 +5,7 @@ using Dapper.Contrib.Extensions;
 
 namespace osu.ElasticIndexer
 {
+    [RulesetId(2)]
     [Table("osu_scores_fruits_high")]
     public class HighScoreFruits : HighScore
     {

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -103,10 +103,13 @@ namespace osu.ElasticIndexer
                             else
                             {
                                 Console.WriteLine("do the other thing");
-                                var models = Model.FetchQueued<T>();
-                                dispatcher.Enqueue(models);
-                                Model.CompleteQueued(models);
-                                count += models.Count;
+                                var chunks = Model.FetchQueued<T>(AppSettings.ChunkSize);
+                                foreach (var chunk in chunks)
+                                {
+                                    dispatcher.Enqueue(chunk);
+                                    Model.CompleteQueued(chunk);
+                                    count += chunk.Count;
+                                }
                             }
 
                             break;

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -96,11 +96,12 @@ namespace osu.ElasticIndexer
                                 var chunks = Model.Chunk<ScoreProcessQueue>($"status = 1 and mode = {mode}", AppSettings.ChunkSize);
                                 foreach (var chunk in chunks)
                                 {
-                                    var scores = ScoreProcessQueue.FetchIds<T>(chunk);
+                                    var scoreIds = chunk.Select(x => x.ScoreId).ToList();
+                                    var scores = ScoreProcessQueue.FetchByScoreIds<T>(scoreIds);
                                     Console.WriteLine($"Got {chunk.Count} items from queue, found {scores.Count} matching scores");
 
                                     dispatcher.Enqueue(scores);
-                                    ScoreProcessQueue.CompleteQueued<T>(chunk);
+                                    ScoreProcessQueue.CompleteQueued<T>(scoreIds);
                                     count += scores.Count;
                                 }
                             }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -33,7 +33,7 @@ namespace osu.ElasticIndexer
             var resumeFrom = ResumeFrom ?? IndexMeta.GetByName(index)?.LastId ?? 0;
 
             Console.WriteLine();
-            Console.WriteLine($"{typeof(T)}, index `{index}`, chunkSize `{AppSettings.ChunkSize}`, resume `{resumeFrom}`");
+            Console.WriteLine($"{typeof(T)}, index `{index}`, chunkSize `{AppSettings.ChunkSize}`, resume `{resumeFrom}`, crawling `{IsCrawler}`");
             Console.WriteLine();
 
             var indexCompletedArgs = new IndexCompletedArgs
@@ -43,7 +43,7 @@ namespace osu.ElasticIndexer
                 StartedAt = DateTime.Now
             };
 
-            dispatcher = new BulkIndexingDispatcher<T>(Name, index);
+            dispatcher = new BulkIndexingDispatcher<T>(Name, index, IsCrawler);
 
             try
             {

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -15,6 +15,7 @@ namespace osu.ElasticIndexer
     {
         public event EventHandler<IndexCompletedArgs> IndexCompleted = delegate { };
 
+        public bool IsCrawler { get; set; }
         public string Name { get; set; }
         public long? ResumeFrom { get; set; }
         public string Suffix { get; set; }
@@ -27,8 +28,9 @@ namespace osu.ElasticIndexer
         public void Run()
         {
             var index = findOrCreateIndex(Name);
-            // find out if we should be resuming
-            var resumeFrom = ResumeFrom ?? IndexMeta.GetByName(index)?.LastId;
+            // find out if we should be resuming; could be resuming from a previously aborted run,
+            // so don't assume the presence of a value means completion.
+            var resumeFrom = ResumeFrom ?? IndexMeta.GetByName(index)?.LastId ?? 0;
 
             Console.WriteLine();
             Console.WriteLine($"{typeof(T)}, index `{index}`, chunkSize `{AppSettings.ChunkSize}`, resume `{resumeFrom}`");
@@ -77,7 +79,7 @@ namespace osu.ElasticIndexer
         /// <param name="resumeFrom">The cursor value to resume from;
         /// use null to resume from the last known value.</param>
         /// <returns>The database reader task.</returns>
-        private Task<long> databaseReaderTask(long? resumeFrom)
+        private Task<long> databaseReaderTask(long resumeFrom)
         {
             return Task.Factory.StartNew(() =>
                 {
@@ -87,13 +89,23 @@ namespace osu.ElasticIndexer
                     {
                         try
                         {
-                            var chunks = Model.Chunk<T>("pp is not null", AppSettings.ChunkSize, resumeFrom);
-                            foreach (var chunk in chunks)
+                            if (IsCrawler)
                             {
-                                dispatcher.Enqueue(chunk);
-                                count += chunk.Count;
-                                // update resumeFrom in this scope to allow resuming from connection errors.
-                                resumeFrom = chunk.Last().CursorValue;
+                                var chunks = Model.Chunk<T>("pp is not null", AppSettings.ChunkSize, resumeFrom);
+                                foreach (var chunk in chunks)
+                                {
+                                    dispatcher.Enqueue(chunk);
+                                    count += chunk.Count;
+                                    // update resumeFrom in this scope to allow resuming from connection errors.
+                                    resumeFrom = chunk.Last().CursorValue;
+                                }
+                            }
+                            else
+                            {
+                                Console.WriteLine("do the other thing");
+                                var models = Model.FetchQueued<T>();
+                                dispatcher.Enqueue(models);
+                                Model.CompleteQueued(models);
                             }
 
                             break;

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -16,7 +16,6 @@ namespace osu.ElasticIndexer
     {
         public event EventHandler<IndexCompletedArgs> IndexCompleted = delegate { };
 
-        public bool IsCrawler { get; set; }
         public string Name { get; set; }
         public long? ResumeFrom { get; set; }
         public string Suffix { get; set; }
@@ -34,7 +33,7 @@ namespace osu.ElasticIndexer
             var resumeFrom = ResumeFrom ?? IndexMeta.GetByName(index)?.LastId ?? 0;
 
             Console.WriteLine();
-            Console.WriteLine($"{typeof(T)}, index `{index}`, chunkSize `{AppSettings.ChunkSize}`, resume `{resumeFrom}`, crawling `{IsCrawler}`");
+            Console.WriteLine($"{typeof(T)}, index `{index}`, chunkSize `{AppSettings.ChunkSize}`, resume `{resumeFrom}`");
             Console.WriteLine();
 
             var indexCompletedArgs = new IndexCompletedArgs
@@ -44,7 +43,7 @@ namespace osu.ElasticIndexer
                 StartedAt = DateTime.Now
             };
 
-            dispatcher = new BulkIndexingDispatcher<T>(Name, index, IsCrawler);
+            dispatcher = new BulkIndexingDispatcher<T>(Name, index);
 
             try
             {
@@ -90,7 +89,7 @@ namespace osu.ElasticIndexer
                     {
                         try
                         {
-                            if (IsCrawler)
+                            if (AppSettings.IsCrawler)
                             {
                                 Console.WriteLine("Crawling records...");
                                 var chunks = Model.Chunk<T>("pp is not null", AppSettings.ChunkSize, resumeFrom);

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -106,6 +106,7 @@ namespace osu.ElasticIndexer
                                 var models = Model.FetchQueued<T>();
                                 dispatcher.Enqueue(models);
                                 Model.CompleteQueued(models);
+                                count += models.Count;
                             }
 
                             break;

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -89,19 +89,7 @@ namespace osu.ElasticIndexer
                     {
                         try
                         {
-                            if (AppSettings.IsCrawler)
-                            {
-                                Console.WriteLine("Crawling records...");
-                                var chunks = Model.Chunk<T>("pp is not null", AppSettings.ChunkSize, resumeFrom);
-                                foreach (var chunk in chunks)
-                                {
-                                    dispatcher.Enqueue(chunk);
-                                    count += chunk.Count;
-                                    // update resumeFrom in this scope to allow resuming from connection errors.
-                                    resumeFrom = chunk.Last().CursorValue;
-                                }
-                            }
-                            else
+                            if (AppSettings.IsUsingQueue)
                             {
                                 Console.WriteLine("Reading from queue...");
                                 var mode = typeof(T).GetCustomAttributes<RulesetId>().First().Id;
@@ -114,6 +102,18 @@ namespace osu.ElasticIndexer
                                     dispatcher.Enqueue(scores);
                                     ScoreProcessQueue.CompleteQueued<T>(chunk);
                                     count += scores.Count;
+                                }
+                            }
+                            else
+                            {
+                                Console.WriteLine("Crawling records...");
+                                var chunks = Model.Chunk<T>("pp is not null", AppSettings.ChunkSize, resumeFrom);
+                                foreach (var chunk in chunks)
+                                {
+                                    dispatcher.Enqueue(chunk);
+                                    count += chunk.Count;
+                                    // update resumeFrom in this scope to allow resuming from connection errors.
+                                    resumeFrom = chunk.Last().CursorValue;
                                 }
                             }
 

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -92,7 +92,7 @@ namespace osu.ElasticIndexer
                             if (AppSettings.IsUsingQueue)
                             {
                                 Console.WriteLine("Reading from queue...");
-                                var mode = typeof(T).GetCustomAttributes<RulesetId>().First().Id;
+                                var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
                                 var chunks = Model.Chunk<ScoreProcessQueue>($"status = 1 and mode = {mode}", AppSettings.ChunkSize);
                                 foreach (var chunk in chunks)
                                 {

--- a/osu.ElasticIndexer/HighScoreMania.cs
+++ b/osu.ElasticIndexer/HighScoreMania.cs
@@ -5,6 +5,7 @@ using Dapper.Contrib.Extensions;
 
 namespace osu.ElasticIndexer
 {
+    [RulesetId(3)]
     [Table("osu_scores_mania_high")]
     public class HighScoreMania : HighScore
     {

--- a/osu.ElasticIndexer/HighScoreOsu.cs
+++ b/osu.ElasticIndexer/HighScoreOsu.cs
@@ -5,6 +5,7 @@ using Dapper.Contrib.Extensions;
 
 namespace osu.ElasticIndexer
 {
+    [RulesetId(0)]
     [Table("osu_scores_high")]
     public class HighScoreOsu : HighScore
     {

--- a/osu.ElasticIndexer/HighScoreTaiko.cs
+++ b/osu.ElasticIndexer/HighScoreTaiko.cs
@@ -5,6 +5,7 @@ using Dapper.Contrib.Extensions;
 
 namespace osu.ElasticIndexer
 {
+    [RulesetId(1)]
     [Table("osu_scores_taiko_high")]
     public class HighScoreTaiko : HighScore
     {

--- a/osu.ElasticIndexer/IIndexer.cs
+++ b/osu.ElasticIndexer/IIndexer.cs
@@ -10,11 +10,6 @@ namespace osu.ElasticIndexer
         event EventHandler<IndexCompletedArgs> IndexCompleted;
 
         /// <summary>
-        /// Does the indexer run as a crawler or not.
-        /// </summary>
-        bool IsCrawler { get; set; }
-
-        /// <summary>
         /// The index's name.
         /// </summary>
         string Name { get; set; }

--- a/osu.ElasticIndexer/IIndexer.cs
+++ b/osu.ElasticIndexer/IIndexer.cs
@@ -10,6 +10,11 @@ namespace osu.ElasticIndexer
         event EventHandler<IndexCompletedArgs> IndexCompleted;
 
         /// <summary>
+        /// Does the indexer run as a crawler or not.
+        /// </summary>
+        bool IsCrawler { get; set; }
+
+        /// <summary>
         /// The index's name.
         /// </summary>
         string Name { get; set; }

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -58,12 +58,17 @@ namespace osu.ElasticIndexer
                 string queueQuery = $"select score_id from score_process_queue where status = 1 and mode = @mode";
                 var scoreIds = dbConnection.Query<long>(queueQuery, new { mode }).AsList();
 
+                Console.WriteLine($"{scoreIds.Count} score_ids found.");
                 if (scoreIds.Count > 0)
                 {
                     string query = $"select * from {table} where score_id in @scoreIds";
-                    return dbConnection.Query<T>(query, new { scoreIds }).AsList();
+                    var records = dbConnection.Query<T>(query, new { scoreIds }).AsList();
+                    Console.WriteLine($"{records.Count} records selected.");
+
+                    return records;
                 }
 
+                Console.WriteLine("no records selected.");
                 return new List<T>(0);
             }
         }

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -58,7 +58,8 @@ namespace osu.ElasticIndexer
                 string queueQuery = $"select score_id from score_process_queue where status = 1 and mode = @mode";
                 var scoreIds = dbConnection.Query<long>(queueQuery, new { mode }).AsList();
 
-                if (scoreIds.Count > 0) {
+                if (scoreIds.Count > 0)
+                {
                     string query = $"select * from {table} where score_id in @scoreIds";
                     return dbConnection.Query<T>(query, new { scoreIds }).AsList();
                 }
@@ -77,8 +78,12 @@ namespace osu.ElasticIndexer
 
                 dbConnection.Open();
 
-                string query = $"update score_process_queue set status = 2 where score_id in @scoreIds and mode = @mode";
-                dbConnection.Execute(query, new { scoreIds, mode });
+                if (scoreIds.Count() > 0)
+                {
+                    string query = $"update score_process_queue set status = 2 where score_id in @scoreIds and mode = @mode";
+                    dbConnection.Execute(query, new { scoreIds, mode });
+                }
+
             }
         }
 

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -31,7 +31,9 @@ namespace osu.ElasticIndexer
 
                 dbConnection.Open();
 
-                var max = dbConnection.QuerySingle<ulong>($"SELECT MAX({cursorColumn}) from {table}");
+                var max = dbConnection.QuerySingle<ulong?>($"SELECT MAX({cursorColumn}) FROM {table} WHERE {where}");
+                if (!max.HasValue) yield break;
+
                 string query = $"select * from {table} where {cursorColumn} > @lastId and {cursorColumn} <= @max {additionalWheres} order by {cursorColumn} asc limit @chunkSize;";
 
                 while (lastId != null)

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -31,11 +31,12 @@ namespace osu.ElasticIndexer
 
                 dbConnection.Open();
 
-                string query = $"select * from {table} where {cursorColumn} > @lastId {additionalWheres} order by {cursorColumn} asc limit @chunkSize;";
+                var max = dbConnection.QuerySingle<ulong>($"SELECT MAX({cursorColumn}) from {table}");
+                string query = $"select * from {table} where {cursorColumn} > @lastId and {cursorColumn} <= @max {additionalWheres} order by {cursorColumn} asc limit @chunkSize;";
 
                 while (lastId != null)
                 {
-                    var parameters = new { lastId, chunkSize };
+                    var parameters = new { lastId, max, chunkSize };
                     Console.WriteLine("{0} {1}", query, parameters);
                     var queryResult = dbConnection.Query<T>(query, parameters).AsList();
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -38,7 +38,7 @@ namespace osu.ElasticIndexer
             DefaultTypeMap.MatchNamesWithUnderscores = true;
             IndexMeta.CreateIndex();
 
-            Console.WriteLine($"Using queue: `{!AppSettings.IsCrawler}`");
+            Console.WriteLine($"Using queue: `{AppSettings.IsUsingQueue}`");
             if (AppSettings.IsWatching)
                 runWatchLoop();
             else

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -43,7 +43,9 @@ namespace osu.ElasticIndexer
             else
             {
                 // do a single run
-                runIndexing(AppSettings.ResumeFrom);
+                runIndexing(AppSettings.ResumeFrom, true);
+                // go through the queue
+                runIndexing(null, false);
             }
 
             if (AppSettings.UseDocker)
@@ -65,12 +67,12 @@ namespace osu.ElasticIndexer
             Console.WriteLine($"Running in watch mode with {AppSettings.PollingInterval}ms poll.");
 
             // run once with config resuming
-            runIndexing(AppSettings.ResumeFrom);
+            runIndexing(AppSettings.ResumeFrom, true);
 
             while (true)
             {
                 // run continuously with automatic resume logic
-                runIndexing(null);
+                runIndexing(null, false);
                 Thread.Sleep(AppSettings.PollingInterval);
             }
         }
@@ -79,7 +81,7 @@ namespace osu.ElasticIndexer
         /// Performs a single indexing run for all specified modes.
         /// </summary>
         /// <param name="resumeFrom">An optional resume point.</param>
-        private static void runIndexing(long? resumeFrom)
+        private static void runIndexing(long? resumeFrom, bool crawl)
         {
             var suffix = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -90,6 +90,7 @@ namespace osu.ElasticIndexer
                 var indexer = getIndexerFromModeString(mode);
                 indexer.Suffix = suffix;
                 indexer.ResumeFrom = resumeFrom;
+                indexer.IsCrawler = crawl;
                 indexer.Run();
             }
         }

--- a/osu.ElasticIndexer/RulesetIdAttribute.cs
+++ b/osu.ElasticIndexer/RulesetIdAttribute.cs
@@ -9,10 +9,10 @@ namespace osu.ElasticIndexer
     /// Integer value of the game mode.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    public class RulesetId : Attribute
+    public class RulesetIdAttribute : Attribute
     {
         public int Id { get; }
 
-        public RulesetId(int id) => Id = id;
+        public RulesetIdAttribute(int id) => Id = id;
     }
 }

--- a/osu.ElasticIndexer/RulesetIdAttribute.cs
+++ b/osu.ElasticIndexer/RulesetIdAttribute.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.ElasticIndexer
+{
+    /// <summary>
+    /// Integer value of the game mode.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class RulesetId : Attribute
+    {
+        public int Id { get; }
+
+        public RulesetId(int id) => Id = id;
+    }
+}

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Dapper;
+using Dapper.Contrib.Extensions;
+using MySql.Data.MySqlClient;
+
+namespace osu.ElasticIndexer
+{
+    [CursorColumn("queue_id")]
+    [Table("score_process_queue")]
+    public class ScoreProcessQueue : Model
+    {
+        public override long CursorValue => QueueId;
+
+        // These are the only columns we care about at the momemnt.
+        public uint QueueId { get; set; }
+
+        public ulong ScoreId { get; set; }
+
+        public static List<T> FetchIds<T>(List<ScoreProcessQueue> items) where T : HighScore
+        {
+            using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
+            {
+                var scoreIds = items.Select(x => x.ScoreId).AsList();
+                var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
+                var mode = typeof(T).GetCustomAttributes<RulesetId>().First().Id;
+
+                dbConnection.Open();
+
+                string query = $"select * from {table} where score_id in @scoreIds";
+                var parameters = new { scoreIds };
+                Console.WriteLine("{0} {1}", query, parameters);
+
+                return dbConnection.Query<T>(query, parameters).AsList();
+            }
+        }
+
+        public static void CompleteQueued<T>(List<ScoreProcessQueue> items) where T : HighScore
+        {
+            using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
+            {
+                var scoreIds = items.Select(x => x.ScoreId).AsList();
+                var mode = typeof(T).GetCustomAttributes<RulesetId>().First().Id;
+
+                dbConnection.Open();
+
+                if (scoreIds.Count() > 0)
+                {
+                    string query = $"update score_process_queue set status = 2 where score_id in @scoreIds and mode = @mode";
+                    dbConnection.Execute(query, new { scoreIds, mode });
+                }
+            }
+        }
+    }
+}

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -28,7 +28,6 @@ namespace osu.ElasticIndexer
             {
                 var scoreIds = items.Select(x => x.ScoreId).AsList();
                 var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
-                var mode = typeof(T).GetCustomAttributes<RulesetId>().First().Id;
 
                 dbConnection.Open();
 
@@ -45,15 +44,14 @@ namespace osu.ElasticIndexer
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
                 var scoreIds = items.Select(x => x.ScoreId).AsList();
-                var mode = typeof(T).GetCustomAttributes<RulesetId>().First().Id;
+                var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+
+                if (!scoreIds.Any()) return;
 
                 dbConnection.Open();
 
-                if (scoreIds.Count() > 0)
-                {
-                    string query = $"update score_process_queue set status = 2 where score_id in @scoreIds and mode = @mode";
-                    dbConnection.Execute(query, new { scoreIds, mode });
-                }
+                const string query = "update score_process_queue set status = 2 where score_id in @scoreIds and mode = @mode";
+                dbConnection.Execute(query, new { scoreIds, mode });
             }
         }
     }

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -22,13 +22,12 @@ namespace osu.ElasticIndexer
 
         public ulong ScoreId { get; set; }
 
-        public static List<T> FetchIds<T>(List<ScoreProcessQueue> items) where T : HighScore
+        public static List<T> FetchByScoreIds<T>(List<ulong> scoreIds) where T : HighScore
         {
+            var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
+
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
-                var scoreIds = items.Select(x => x.ScoreId).AsList();
-                var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
-
                 dbConnection.Open();
 
                 string query = $"select * from {table} where score_id in @scoreIds";
@@ -39,14 +38,13 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static void CompleteQueued<T>(List<ScoreProcessQueue> items) where T : HighScore
+        public static void CompleteQueued<T>(List<ulong> scoreIds) where T : HighScore
         {
+            if (!scoreIds.Any()) return;
+
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
-                var scoreIds = items.Select(x => x.ScoreId).AsList();
                 var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
-
-                if (!scoreIds.Any()) return;
 
                 dbConnection.Open();
 


### PR DESCRIPTION
This adds support for getting the list of scores that need updating from `score_process_queue`.
It will only use the queue _or_ crawl the database from a resume point, in a single process, but not both. The default is to use the queue and `crawl=1` has to be explicitly set to enable indexing from a resume point.

TODO:
- remove deleted scores from index
- read scores/update queue on different connections

