### PR TITLE
Add support for deleting scores from index

### DIFF
--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -53,7 +53,7 @@ namespace osu.ElasticIndexer
 
             ConnectionString = config.GetConnectionString("osu");
             IsNew = parseBool("new");
-            IsUsingQueue = !parseBool("crawl");
+            IsRebuild = parseBool("rebuild");
             IsWatching = parseBool("watch");
             Prefix = config["elasticsearch:prefix"];
 
@@ -82,9 +82,8 @@ namespace osu.ElasticIndexer
 
         public static bool IsNew { get; private set; }
 
-        public static bool IsRebuild { get { return !IsUsingQueue; } }
 
-        public static bool IsUsingQueue { get; private set; }
+        public static bool IsRebuild { get; private set; }
 
         public static bool IsWatching { get; private set; }
 

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -63,6 +63,8 @@ namespace osu.ElasticIndexer
             ELASTIC_CLIENT = new ElasticClient(new ConnectionSettings(new Uri(ElasticsearchHost)));
 
             UseDocker = Environment.GetEnvironmentVariable("DOCKER")?.Contains("1") ?? false;
+
+            assertOptionsCompatible();
         }
 
         // same value as elasticsearch-net
@@ -80,6 +82,8 @@ namespace osu.ElasticIndexer
 
         public static bool IsNew { get; private set; }
 
+        public static bool IsRebuild { get { return !IsUsingQueue; } }
+
         public static bool IsUsingQueue { get; private set; }
 
         public static bool IsWatching { get; private set; }
@@ -95,6 +99,12 @@ namespace osu.ElasticIndexer
         public static ulong? ResumeFrom { get; private set; }
 
         public static bool UseDocker { get; private set; }
+
+        private static void assertOptionsCompatible()
+        {
+            if (IsRebuild && IsWatching)
+                throw new Exception("watch mode cannot be used with index rebuilding.");
+        }
 
         private static bool parseBool(string key)
         {

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -43,7 +43,7 @@ namespace osu.ElasticIndexer
                 BufferSize = int.Parse(config["buffer_size"]);
 
             if (!string.IsNullOrEmpty(config["resume_from"]))
-                ResumeFrom = long.Parse(config["resume_from"]);
+                ResumeFrom = ulong.Parse(config["resume_from"]);
 
             if (!string.IsNullOrEmpty(config["polling_interval"]))
                 PollingInterval = int.Parse(config["polling_interval"]);
@@ -92,7 +92,7 @@ namespace osu.ElasticIndexer
 
         public static int BufferSize { get; private set; } = 5;
 
-        public static long? ResumeFrom { get; private set; }
+        public static ulong? ResumeFrom { get; private set; }
 
         public static bool UseDocker { get; private set; }
 

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -28,7 +28,7 @@ namespace osu.ElasticIndexer
             this.index = index;
         }
 
-        internal void Enqueue(List<T> add = null, List<string> remove = null) => readBuffer.Add(new DispatcherQueueItem<T>(add, remove));
+        internal void Enqueue(List<T> add = null, List<T> remove = null) => readBuffer.Add(new DispatcherQueueItem<T>(add, remove));
         internal void EnqueueEnd() => readBuffer.CompleteAdding();
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace osu.ElasticIndexer
                     var bulkDescriptor = new BulkDescriptor()
                         .Index(index)
                         .IndexMany(chunk.IndexItems)
-                        .DeleteMany(chunk.DeleteIds);
+                        .DeleteMany(chunk.DeleteItems);
                     var response = elasticClient.Bulk(bulkDescriptor);
 
                     bool retry;

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -12,7 +12,7 @@ namespace osu.ElasticIndexer
 {
     internal class BulkIndexingDispatcher<T> where T : HighScore
     {
-        internal event EventHandler<ulong> BatchWithLastIdCompleted = delegate { };
+        internal event EventHandler<ulong> BatchWithLastIdCompleted;
 
         // use shared instance to avoid socket leakage.
         private readonly ElasticClient elasticClient = AppSettings.ELASTIC_CLIENT;
@@ -66,7 +66,7 @@ namespace osu.ElasticIndexer
                 }
 
                 if (success)
-                    BatchWithLastIdCompleted(this, chunk.ItemsToIndex.Last().ScoreId);
+                    BatchWithLastIdCompleted?.Invoke(this, chunk.ItemsToIndex.Last().ScoreId);
             });
         }
 

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -28,7 +28,7 @@ namespace osu.ElasticIndexer
             this.index = index;
         }
 
-        internal void Enqueue(List<T> add = null, List<long> remove = null) => readBuffer.Add(new DispatcherQueueItem<T>(add, remove) );
+        internal void Enqueue(List<T> add = null, List<string> remove = null) => readBuffer.Add(new DispatcherQueueItem<T>(add, remove));
         internal void EnqueueEnd() => readBuffer.CompleteAdding();
 
         /// <summary>
@@ -51,10 +51,14 @@ namespace osu.ElasticIndexer
 
                 while (true)
                 {
+                    var bulkDescriptor = new BulkDescriptor()
+                        .Index(index)
+                        .IndexMany(chunk.IndexItems)
+                        .DeleteMany(chunk.DeleteIds);
+                    var response = elasticClient.Bulk(bulkDescriptor);
+
                     bool retry;
-                    // TODO: do index or delete only, not both.
-                    (success, retry) = bulkIndex(chunk.IndexItems);
-                    (success, retry) = delete(chunk.DeleteScoreIds);
+                    (success, retry) = retryOnResponse(response, chunk);
 
                     if (!retry) break;
 
@@ -77,39 +81,12 @@ namespace osu.ElasticIndexer
             IndexMeta.Refresh();
         }
 
-        private (bool success, bool retry) bulkIndex(List<T> items)
-        {
-            if (items == null) return (success: true, retry: false);
-
-            var bulkDescriptor = new BulkDescriptor().Index(index).IndexMany(items);
-            var response = elasticClient.Bulk(bulkDescriptor);
-
-            return retryOnResponse(response, items);
-        }
-
-        private (bool success, bool retry) delete(List<long> scoreIds)
-        {
-            if (scoreIds == null) return (success: true, retry: false);
-
-            var deleteResponse = elasticClient.DeleteByQuery<T>(d => d
-                .Index(index)
-                .Query(q => q
-                    .Terms(t => t
-                        .Field(s => s.ScoreId)
-                        .Terms(scoreIds)
-                    )
-                )
-            );
-
-            return (success: true, retry: false);
-        }
-
-        private (bool success, bool retry) retryOnResponse(IBulkResponse response, List<T> items)
+        private (bool success, bool retry) retryOnResponse(IBulkResponse response, DispatcherQueueItem<T> queued)
         {
             // Elasticsearch bulk thread pool is full.
             if (response.ItemsWithErrors.Any(item => item.Status == 429 || item.Error.Type == "es_rejected_execution_exception"))
             {
-                Console.WriteLine($"Server returned 429, re-queued chunk with lastId {items.Last().CursorValue}");
+                Console.WriteLine($"Server returned 429, re-queued chunk with lastId {queued.IndexItems.Last().CursorValue}");
                 return (success: false, retry: true);
             }
 

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -53,8 +53,8 @@ namespace osu.ElasticIndexer
                 {
                     var bulkDescriptor = new BulkDescriptor()
                         .Index(index)
-                        .IndexMany(chunk.IndexItems)
-                        .DeleteMany(chunk.DeleteItems);
+                        .IndexMany(chunk.ItemsToIndex)
+                        .DeleteMany(chunk.ItemsToDelete);
                     var response = elasticClient.Bulk(bulkDescriptor);
 
                     bool retry;
@@ -66,7 +66,7 @@ namespace osu.ElasticIndexer
                 }
 
                 if (success)
-                    BatchWithLastIdCompleted(this, chunk.IndexItems.Last().ScoreId);
+                    BatchWithLastIdCompleted(this, chunk.ItemsToIndex.Last().ScoreId);
             });
         }
 
@@ -75,7 +75,7 @@ namespace osu.ElasticIndexer
             // Elasticsearch bulk thread pool is full.
             if (response.ItemsWithErrors.Any(item => item.Status == 429 || item.Error.Type == "es_rejected_execution_exception"))
             {
-                Console.WriteLine($"Server returned 429, re-queued chunk with lastId {queued.IndexItems.Last().CursorValue}");
+                Console.WriteLine($"Server returned 429, re-queued chunk with lastId {queued.ItemsToIndex.Last().CursorValue}");
                 return (success: false, retry: true);
             }
 

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -14,8 +14,8 @@ namespace osu.ElasticIndexer
         public IEnumerable<T> ItemsToIndex { get; private set; }
 
         public DispatcherQueueItem(IEnumerable<T> add, IEnumerable<T> remove) {
-            ItemsToIndex = add ?? empty_list;
-            ItemsToDelete = remove ?? empty_list;
+            ItemsToIndex = add ?? Enumerable.Empty<T>();
+            ItemsToDelete = remove ?? Enumerable.Empty<T>();
         }
     }
 }

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -2,21 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.ElasticIndexer
 {
     public class DispatcherQueueItem<T> where T : HighScore
     {
-        private static readonly List<T> EmptyList = new List<T>(0);
+        private static readonly List<T> empty_list = new List<T>(0);
 
         public List<T> IndexItems { get; private set; }
 
         public List<T> DeleteItems { get; private set; }
 
         public DispatcherQueueItem(List<T> index, List<T> delete) {
-            IndexItems = index ?? EmptyList;
-            DeleteItems = delete ?? EmptyList;
+            IndexItems = index ?? empty_list;
+            DeleteItems = delete ?? empty_list;
         }
     }
 }

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -8,15 +8,15 @@ namespace osu.ElasticIndexer
 {
     public class DispatcherQueueItem<T> where T : HighScore
     {
-        private static readonly List<string> EmptyDeleteList = new List<string>(0);
+        private static readonly List<T> EmptyList = new List<T>(0);
 
         public List<T> IndexItems { get; private set; }
 
-        public List<string> DeleteIds { get; private set; }
+        public List<T> DeleteItems { get; private set; }
 
-        public DispatcherQueueItem(List<T> index, List<string> delete = null) {
-            IndexItems = index.Where(x => x.ShouldIndex).ToList(); // this should probably not go here?
-            DeleteIds = delete ?? EmptyDeleteList;
+        public DispatcherQueueItem(List<T> index, List<T> delete) {
+            IndexItems = index ?? EmptyList;
+            DeleteItems = delete ?? EmptyList;
         }
     }
 }

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -8,8 +8,6 @@ namespace osu.ElasticIndexer
 {
     public class DispatcherQueueItem<T> where T : HighScore
     {
-        private static readonly IEnumerable<T> empty_list = new ReadOnlyCollection<T>(new List<T>(0));
-
         public IEnumerable<T> ItemsToDelete { get; private set; }
         public IEnumerable<T> ItemsToIndex { get; private set; }
 

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -2,20 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace osu.ElasticIndexer
 {
     public class DispatcherQueueItem<T> where T : HighScore
     {
-        private static readonly List<T> empty_list = new List<T>(0);
+        private static readonly IEnumerable<T> empty_list = new ReadOnlyCollection<T>(new List<T>(0));
 
-        public List<T> IndexItems { get; private set; }
+        public IEnumerable<T> ItemsToDelete { get; private set; }
+        public IEnumerable<T> ItemsToIndex { get; private set; }
 
-        public List<T> DeleteItems { get; private set; }
-
-        public DispatcherQueueItem(List<T> index, List<T> delete) {
-            IndexItems = index ?? empty_list;
-            DeleteItems = delete ?? empty_list;
+        public DispatcherQueueItem(IEnumerable<T> add, IEnumerable<T> remove) {
+            ItemsToIndex = add ?? empty_list;
+            ItemsToDelete = remove ?? empty_list;
         }
     }
 }

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -2,18 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace osu.ElasticIndexer
 {
     public class DispatcherQueueItem<T> where T : HighScore
     {
+        private static readonly List<string> EmptyDeleteList = new List<string>(0);
+
         public List<T> IndexItems { get; private set; }
 
-        public List<long> DeleteScoreIds { get; private set; }
+        public List<string> DeleteIds { get; private set; }
 
-        public DispatcherQueueItem(List<T> index, List<long> delete = null) {
-            IndexItems = index;
-            DeleteScoreIds = delete;
+        public DispatcherQueueItem(List<T> index, List<string> delete = null) {
+            IndexItems = index.Where(x => x.ShouldIndex).ToList(); // this should probably not go here?
+            DeleteIds = delete ?? EmptyDeleteList;
         }
     }
 }

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.ElasticIndexer
+{
+    public class DispatcherQueueItem<T> where T : HighScore
+    {
+        public List<T> IndexItems { get; private set; }
+        public List<T> DeleteItems { get; private set; }
+
+        public DispatcherQueueItem(List<T> index, List<T> delete = null) {
+            IndexItems = index;
+            DeleteItems = delete;
+        }
+    }
+}

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace osu.ElasticIndexer
 {

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -8,11 +8,12 @@ namespace osu.ElasticIndexer
     public class DispatcherQueueItem<T> where T : HighScore
     {
         public List<T> IndexItems { get; private set; }
-        public List<T> DeleteItems { get; private set; }
 
-        public DispatcherQueueItem(List<T> index, List<T> delete = null) {
+        public List<long> DeleteScoreIds { get; private set; }
+
+        public DispatcherQueueItem(List<T> index, List<long> delete = null) {
             IndexItems = index;
-            DeleteItems = delete;
+            DeleteScoreIds = delete;
         }
     }
 }

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Dapper.Contrib.Extensions;
 using Nest;
 
@@ -130,6 +131,11 @@ namespace osu.ElasticIndexer
             }
 
             return mods.Values.ToList();
+        }
+
+        public static int GetRulesetId<T>() where T : HighScore
+        {
+            return typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
         }
     }
 }

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -24,7 +24,7 @@ namespace osu.ElasticIndexer
         public string Id => $"{UserId}-{BeatmapId}-{EnabledMods}";
 
         [Number(NumberType.Long, Name = "score_id")]
-        public uint ScoreId { get; set; }
+        public long ScoreId { get; set; }
 
         [Number(NumberType.Long, Name = "beatmap_id")]
         public uint BeatmapId { get; set; }

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -15,7 +15,7 @@ namespace osu.ElasticIndexer
     {
         [Computed]
         [Ignore]
-        public override long CursorValue => (long) ScoreId;
+        public override ulong CursorValue => ScoreId;
 
         [Computed]
         [Ignore]

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -15,7 +15,7 @@ namespace osu.ElasticIndexer
     {
         [Computed]
         [Ignore]
-        public override long CursorValue => ScoreId;
+        public override long CursorValue => (long) ScoreId;
 
         [Computed]
         [Ignore]
@@ -28,7 +28,7 @@ namespace osu.ElasticIndexer
         public string Id => $"{UserId}-{BeatmapId}-{EnabledMods}";
 
         [Number(NumberType.Long, Name = "score_id")]
-        public long ScoreId { get; set; }
+        public ulong ScoreId { get; set; }
 
         [Number(NumberType.Long, Name = "beatmap_id")]
         public uint BeatmapId { get; set; }

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -10,12 +10,16 @@ using Nest;
 namespace osu.ElasticIndexer
 {
     [CursorColumn("score_id")]
-    [ElasticsearchType(Name = "high_score", IdProperty = nameof(Id))]
+    [ElasticsearchType(Name = "high_score", IdProperty = nameof(ScoreId))]
     public abstract class HighScore : Model
     {
         [Computed]
         [Ignore]
         public override long CursorValue => ScoreId;
+
+        [Computed]
+        [Ignore]
+        public bool ShouldIndex => Pp > 0;
 
         // Properties ordered in the order they appear in the table.
 

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -19,13 +19,9 @@ namespace osu.ElasticIndexer
 
         [Computed]
         [Ignore]
-        public bool ShouldIndex => Pp > 0;
+        public bool ShouldIndex => Pp.HasValue;
 
         // Properties ordered in the order they appear in the table.
-
-        [Computed]
-        [Ignore]
-        public string Id => $"{UserId}-{BeatmapId}-{EnabledMods}";
 
         [Number(NumberType.Long, Name = "score_id")]
         public ulong ScoreId { get; set; }
@@ -77,7 +73,7 @@ namespace osu.ElasticIndexer
         public DateTimeOffset Date { get; set; }
 
         [Number(NumberType.Float, Name = "pp")]
-        public float Pp { get; set; }
+        public float? Pp { get; set; }
 
         [Boolean(Name = "replay")]
         public bool Replay { get; set; }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -98,7 +98,10 @@ namespace osu.ElasticIndexer
                                 {
                                     var scoreIds = chunk.Select(x => x.ScoreId).ToList();
                                     var scores = ScoreProcessQueue.FetchByScoreIds<T>(scoreIds);
-                                    var removedScores = scoreIds.Except(scores.Select(x => x.ScoreId)).ToList();
+                                    var removedScores = scoreIds
+                                        .Except(scores.Select(x => x.ScoreId))
+                                        .Select(x => x.ToString())
+                                        .ToList();
                                     Console.WriteLine($"Got {chunk.Count} items from queue, found {scores.Count} matching scores, {removedScores.Count} missing scores");
 
                                     dispatcher.Enqueue(add: scores, remove: removedScores);
@@ -109,7 +112,7 @@ namespace osu.ElasticIndexer
                             else
                             {
                                 Console.WriteLine("Crawling records...");
-                                var chunks = Model.Chunk<T>("pp is not null", AppSettings.ChunkSize, resumeFrom);
+                                var chunks = Model.Chunk<T>(AppSettings.ChunkSize, resumeFrom);
                                 foreach (var chunk in chunks)
                                 {
                                     dispatcher.Enqueue(chunk);

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -98,9 +98,10 @@ namespace osu.ElasticIndexer
                                 {
                                     var scoreIds = chunk.Select(x => x.ScoreId).ToList();
                                     var scores = ScoreProcessQueue.FetchByScoreIds<T>(scoreIds);
-                                    Console.WriteLine($"Got {chunk.Count} items from queue, found {scores.Count} matching scores");
+                                    var removedScores = scoreIds.Except(scores.Select(x => x.ScoreId)).ToList();
+                                    Console.WriteLine($"Got {chunk.Count} items from queue, found {scores.Count} matching scores, {removedScores.Count} missing scores");
 
-                                    dispatcher.Enqueue(scores);
+                                    dispatcher.Enqueue(add: scores, remove: removedScores);
                                     ScoreProcessQueue.CompleteQueued<T>(scoreIds);
                                     count += scores.Count;
                                 }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -205,7 +205,7 @@ namespace osu.ElasticIndexer
                 if (indexMeta.ResetQueueTo.HasValue) return;
 
                 var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
-                indexMeta.ResetQueueTo = ScoreProcessQueue.GetFirstPendingQueueId(mode);
+                indexMeta.ResetQueueTo = ScoreProcessQueue.GetLastProcessedQueueId(mode);
             }
             else
             {

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -17,7 +17,7 @@ namespace osu.ElasticIndexer
         public event EventHandler<IndexCompletedArgs> IndexCompleted = delegate { };
 
         public string Name { get; set; }
-        public long? ResumeFrom { get; set; }
+        public ulong? ResumeFrom { get; set; }
         public string Suffix { get; set; }
 
         // use shared instance to avoid socket leakage.
@@ -79,7 +79,7 @@ namespace osu.ElasticIndexer
         /// <param name="resumeFrom">The cursor value to resume from;
         /// use null to resume from the last known value.</param>
         /// <returns>The database reader task.</returns>
-        private Task<long> databaseReaderTask(long resumeFrom)
+        private Task<long> databaseReaderTask(ulong resumeFrom)
         {
             return Task.Factory.StartNew(() =>
                 {

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -108,7 +108,7 @@ namespace osu.ElasticIndexer
                     {
                         try
                         {
-                            if (AppSettings.IsUsingQueue)
+                            if (!AppSettings.IsRebuild)
                             {
                                 Console.WriteLine("Reading from queue...");
                                 var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
@@ -130,7 +130,7 @@ namespace osu.ElasticIndexer
                             }
                             else
                             {
-                                Console.WriteLine("Crawling records...");
+                                Console.WriteLine($"Rebuild from {resumeFrom}...");
                                 var chunks = Model.Chunk<T>(AppSettings.ChunkSize, resumeFrom);
                                 foreach (var chunk in chunks)
                                 {

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Data.Common;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Nest;
@@ -102,7 +101,7 @@ namespace osu.ElasticIndexer
                             if (!AppSettings.IsRebuild)
                             {
                                 Console.WriteLine("Reading from queue...");
-                                var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+                                var mode = HighScore.GetRulesetId<T>();
                                 var chunks = Model.Chunk<ScoreProcessQueue>($"status = 1 and mode = {mode}", AppSettings.ChunkSize);
                                 foreach (var chunk in chunks)
                                 {
@@ -220,7 +219,7 @@ namespace osu.ElasticIndexer
                 // so we likely want to preserve that value.
                 if (!indexMeta.ResetQueueTo.HasValue)
                 {
-                    var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+                    var mode = HighScore.GetRulesetId<T>();
                     indexMeta.ResetQueueTo = ScoreProcessQueue.GetLastProcessedQueueId(mode);
                 }
             }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -202,13 +202,11 @@ namespace osu.ElasticIndexer
         {
             var index = findOrCreateIndex(Name);
             // look for any existing resume data.
-            var indexMeta = IndexMeta.GetByName(index);
-            if (indexMeta == null)
-                indexMeta = new IndexMeta
-                {
-                    Alias = Name,
-                    Index = index,
-                };
+            var indexMeta = IndexMeta.GetByName(index) ?? new IndexMeta
+            {
+                Alias = Name,
+                Index = index,
+            };
 
             indexMeta.LastId = ResumeFrom ?? indexMeta.LastId;
 

--- a/osu.ElasticIndexer/IIndexer.cs
+++ b/osu.ElasticIndexer/IIndexer.cs
@@ -10,13 +10,6 @@ namespace osu.ElasticIndexer
         event EventHandler<IndexCompletedArgs> IndexCompleted;
 
         /// <summary>
-        /// The ID where the queue-based indexer should be forced to restart from on its next pass,
-        ///  after the index is rebuilt.
-        /// </summary>
-        /// <value></value>
-        ulong? FirstPendingQueueId { get; set; }
-
-        /// <summary>
         /// The index's name.
         /// </summary>
         string Name { get; set; }

--- a/osu.ElasticIndexer/IIndexer.cs
+++ b/osu.ElasticIndexer/IIndexer.cs
@@ -17,7 +17,7 @@ namespace osu.ElasticIndexer
         /// <summary>
         /// The ID from which to resume indexing from. If null, the most recent ID is used.
         /// </summary>
-        long? ResumeFrom { get; set; }
+        ulong? ResumeFrom { get; set; }
 
         /// <summary>
         /// The index suffix (generally a timestamp string).

--- a/osu.ElasticIndexer/IIndexer.cs
+++ b/osu.ElasticIndexer/IIndexer.cs
@@ -10,6 +10,13 @@ namespace osu.ElasticIndexer
         event EventHandler<IndexCompletedArgs> IndexCompleted;
 
         /// <summary>
+        /// The ID where the queue-based indexer should be forced to restart from on its next pass,
+        ///  after the index is rebuilt.
+        /// </summary>
+        /// <value></value>
+        ulong? FirstPendingQueueId { get; set; }
+
+        /// <summary>
         /// The index's name.
         /// </summary>
         string Name { get; set; }

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -34,6 +34,9 @@ namespace osu.ElasticIndexer
         [Number(NumberType.Long, Name = "last_id")]
         public ulong LastId { get; set; }
 
+        [Number(NumberType.Long, Name = "reset_queue_to")]
+        public ulong? ResetQueueTo { get; set; }
+
         [Date(Name = "updated_at")]
         public DateTimeOffset UpdatedAt { get; set; }
 

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -32,7 +32,7 @@ namespace osu.ElasticIndexer
         public string Alias { get; set; }
 
         [Number(NumberType.Long, Name = "last_id")]
-        public long LastId { get; set; }
+        public ulong LastId { get; set; }
 
         [Date(Name = "updated_at")]
         public DateTimeOffset UpdatedAt { get; set; }

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -31,7 +31,7 @@ namespace osu.ElasticIndexer
 
                 dbConnection.Open();
 
-                var max = dbConnection.QuerySingle<ulong?>($"SELECT MAX({cursorColumn}) FROM {table} WHERE {where}");
+                var max = dbConnection.QuerySingle<long?>($"SELECT MAX({cursorColumn}) FROM {table} WHERE {where}");
                 if (!max.HasValue) yield break;
 
                 string query = $"select * from {table} where {cursorColumn} > @lastId and {cursorColumn} <= @max {additionalWheres} order by {cursorColumn} asc limit @chunkSize;";

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -14,13 +14,13 @@ namespace osu.ElasticIndexer
     [CursorColumn("id")]
     public abstract class Model
     {
-        public abstract long CursorValue { get; }
+        public abstract ulong CursorValue { get; }
 
-        public static IEnumerable<List<T>> Chunk<T>(string where, int chunkSize = 10000, long? resumeFrom = null) where T : Model
+        public static IEnumerable<List<T>> Chunk<T>(string where, int chunkSize = 10000, ulong? resumeFrom = null) where T : Model
         {
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
-                long? lastId = resumeFrom ?? 0;
+                ulong? lastId = resumeFrom ?? 0;
                 var cursorColumn = typeof(T).GetCustomAttributes<CursorColumnAttribute>().First().Name;
                 var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
 
@@ -51,7 +51,7 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static IEnumerable<List<T>> Chunk<T>(int chunkSize = 10000, long? resumeFrom = null) where T : Model =>
+        public static IEnumerable<List<T>> Chunk<T>(int chunkSize = 10000, ulong? resumeFrom = null) where T : Model =>
             Chunk<T>(null, chunkSize, resumeFrom);
     }
 }

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -21,8 +21,8 @@ namespace osu.ElasticIndexer
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
                 ulong? lastId = resumeFrom ?? 0;
-                var cursorColumn = typeof(T).GetCustomAttributes<CursorColumnAttribute>().First().Name;
-                var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
+                var cursorColumn = Model.GetCursorColumnName<T>();
+                var table = Model.GetTableName<T>();
 
                 Console.WriteLine($"Starting {table} from {lastId}...");
 
@@ -53,5 +53,15 @@ namespace osu.ElasticIndexer
 
         public static IEnumerable<List<T>> Chunk<T>(int chunkSize = 10000, ulong? resumeFrom = null) where T : Model =>
             Chunk<T>(null, chunkSize, resumeFrom);
+
+        public static string GetCursorColumnName<T>() where T : Model
+        {
+            return typeof(T).GetCustomAttributes<CursorColumnAttribute>().First().Name;
+        }
+
+        public static string GetTableName<T>() where T : Model
+        {
+            return typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
+        }
     }
 }

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -21,8 +21,8 @@ namespace osu.ElasticIndexer
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
                 ulong? lastId = resumeFrom ?? 0;
-                var cursorColumn = Model.GetCursorColumnName<T>();
-                var table = Model.GetTableName<T>();
+                var cursorColumn = GetCursorColumnName<T>();
+                var table = GetTableName<T>();
 
                 Console.WriteLine($"Starting {table} from {lastId}...");
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -39,7 +39,7 @@ namespace osu.ElasticIndexer
             DefaultTypeMap.MatchNamesWithUnderscores = true;
             IndexMeta.CreateIndex();
 
-            Console.WriteLine($"rebuilding index: `{AppSettings.IsRebuild}`");
+            Console.WriteLine($"Rebuilding index: `{AppSettings.IsRebuild}`");
             if (AppSettings.IsWatching)
                 runWatchLoop();
             else

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using System.Threading;
-using System.Linq;
 using Dapper;
 using MySql.Data.MySqlClient;
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -42,9 +42,7 @@ namespace osu.ElasticIndexer
             if (AppSettings.IsWatching)
                 runWatchLoop();
             else
-            {
-                runIndexing(AppSettings.ResumeFrom);
-            }
+                runIndexing();
 
             if (AppSettings.UseDocker)
             {
@@ -67,7 +65,7 @@ namespace osu.ElasticIndexer
             while (true)
             {
                 // run continuously with automatic resume logic
-                runIndexing(null);
+                runIndexing();
                 Thread.Sleep(AppSettings.PollingInterval);
             }
         }
@@ -75,8 +73,7 @@ namespace osu.ElasticIndexer
         /// <summary>
         /// Performs a single indexing run for all specified modes.
         /// </summary>
-        /// <param name="resumeFrom">An optional resume point.</param>
-        private static void runIndexing(ulong? resumeFrom)
+        private static void runIndexing()
         {
             var suffix = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
 
@@ -84,7 +81,7 @@ namespace osu.ElasticIndexer
             {
                 var indexer = getIndexerFromModeString(mode);
                 indexer.Suffix = suffix;
-                indexer.ResumeFrom = resumeFrom;
+                indexer.ResumeFrom = AppSettings.ResumeFrom;
                 indexer.Run();
             }
         }

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -79,7 +79,7 @@ namespace osu.ElasticIndexer
         /// Performs a single indexing run for all specified modes.
         /// </summary>
         /// <param name="resumeFrom">An optional resume point.</param>
-        private static void runIndexing(long? resumeFrom)
+        private static void runIndexing(ulong? resumeFrom)
         {
             var suffix = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -39,7 +39,7 @@ namespace osu.ElasticIndexer
             DefaultTypeMap.MatchNamesWithUnderscores = true;
             IndexMeta.CreateIndex();
 
-            Console.WriteLine($"Using queue: `{AppSettings.IsUsingQueue}`");
+            Console.WriteLine($"rebuilding index: `{AppSettings.IsRebuild}`");
             if (AppSettings.IsWatching)
                 runWatchLoop();
             else

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -80,14 +80,9 @@ namespace osu.ElasticIndexer
 
             foreach (var mode in AppSettings.Modes)
             {
-                var type = getTypeFromModeString(mode);
-                var modeInt = ((RulesetIdAttribute) type.GetCustomAttributes(typeof(RulesetIdAttribute), true).First()).Id;
-                var firstPendingQueueId = AppSettings.IsRebuild ? ScoreProcessQueue.GetFirstPendingQueueId(modeInt) : null;
-
                 var indexer = getIndexerFromModeString(mode);
                 indexer.Suffix = suffix;
                 indexer.ResumeFrom = AppSettings.ResumeFrom;
-                indexer.FirstPendingQueueId = firstPendingQueueId;
                 indexer.Run();
             }
         }

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -87,10 +87,8 @@ namespace osu.ElasticIndexer
                 var indexer = getIndexerFromModeString(mode);
                 indexer.Suffix = suffix;
                 indexer.ResumeFrom = AppSettings.ResumeFrom;
+                indexer.FirstPendingQueueId = firstPendingQueueId;
                 indexer.Run();
-
-                if (firstPendingQueueId.HasValue)
-                    ScoreProcessQueue.UnCompleteQueued(modeInt, firstPendingQueueId.Value);
             }
         }
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -64,9 +64,6 @@ namespace osu.ElasticIndexer
         {
             Console.WriteLine($"Running in watch mode with {AppSettings.PollingInterval}ms poll.");
 
-            // run once with config resuming
-            runIndexing(AppSettings.ResumeFrom);
-
             while (true)
             {
                 // run continuously with automatic resume logic

--- a/osu.ElasticIndexer/RulesetIdAttribute.cs
+++ b/osu.ElasticIndexer/RulesetIdAttribute.cs
@@ -14,7 +14,5 @@ namespace osu.ElasticIndexer
         public int Id { get; }
 
         public RulesetIdAttribute(int id) => Id = id;
-
-
-    }
+   }
 }

--- a/osu.ElasticIndexer/RulesetIdAttribute.cs
+++ b/osu.ElasticIndexer/RulesetIdAttribute.cs
@@ -14,5 +14,7 @@ namespace osu.ElasticIndexer
         public int Id { get; }
 
         public RulesetIdAttribute(int id) => Id = id;
+
+
     }
 }

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -52,5 +52,27 @@ namespace osu.ElasticIndexer
                 return dbConnection.Query<T>(query, parameters).AsList();
             }
         }
+
+        public static ulong? GetFirstPendingQueueId(int mode)
+        {
+            using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
+            {
+                dbConnection.Open();
+
+                const string query = "select MIN(queue_id) from score_process_queue where mode = @mode";
+                return dbConnection.QuerySingleOrDefault<ulong>(query, new { mode });
+            }
+        }
+
+        public static void UnCompleteQueued(int mode, ulong from)
+        {
+            using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
+            {
+                dbConnection.Open();
+
+                const string query = "update score_process_queue set status = 1 where queue_id >= @from and mode = @mode";
+                dbConnection.Execute(query, new { from, mode });
+            }
+        }
     }
 }

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -20,9 +20,9 @@ namespace osu.ElasticIndexer
         // These are the only columns we care about at the momemnt.
         public uint QueueId { get; set; }
 
-        public ulong ScoreId { get; set; }
+        public long ScoreId { get; set; }
 
-        public static void CompleteQueued<T>(List<ulong> scoreIds) where T : HighScore
+        public static void CompleteQueued<T>(List<long> scoreIds) where T : HighScore
         {
             if (!scoreIds.Any()) return;
 
@@ -37,7 +37,7 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static List<T> FetchByScoreIds<T>(List<ulong> scoreIds) where T : HighScore
+        public static List<T> FetchByScoreIds<T>(List<long> scoreIds) where T : HighScore
         {
             var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -60,7 +60,7 @@ namespace osu.ElasticIndexer
                 dbConnection.Open();
 
                 const string query = "SELECT MAX(queue_id) FROM score_process_queue WHERE status = 2 AND mode = @mode";
-                return dbConnection.QuerySingleOrDefault<ulong>(query, new { mode });
+                return dbConnection.QuerySingle<ulong?>(query, new { mode });
             }
         }
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -20,9 +20,9 @@ namespace osu.ElasticIndexer
         // These are the only columns we care about at the momemnt.
         public uint QueueId { get; set; }
 
-        public long ScoreId { get; set; }
+        public ulong ScoreId { get; set; }
 
-        public static void CompleteQueued<T>(List<long> scoreIds) where T : HighScore
+        public static void CompleteQueued<T>(List<ulong> scoreIds) where T : HighScore
         {
             if (!scoreIds.Any()) return;
 
@@ -37,7 +37,7 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static List<T> FetchByScoreIds<T>(List<long> scoreIds) where T : HighScore
+        public static List<T> FetchByScoreIds<T>(List<ulong> scoreIds) where T : HighScore
         {
             var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -15,7 +15,7 @@ namespace osu.ElasticIndexer
     [Table("score_process_queue")]
     public class ScoreProcessQueue : Model
     {
-        public override long CursorValue => QueueId;
+        public override ulong CursorValue => QueueId;
 
         // These are the only columns we care about at the momemnt.
         public uint QueueId { get; set; }

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -38,7 +38,7 @@ namespace osu.ElasticIndexer
 
         public static List<T> FetchByScoreIds<T>(List<ulong> scoreIds) where T : HighScore
         {
-            var table = Model.GetTableName<T>();
+            var table = GetTableName<T>();
 
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -64,10 +64,12 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static void UnCompleteQueued(int mode, ulong from)
+        public static void UnCompleteQueued<T>(ulong from) where T : HighScore
         {
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
+                var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+
                 dbConnection.Open();
 
                 const string query = "update score_process_queue set status = 1 where queue_id >= @from and mode = @mode";

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Dapper;
 using Dapper.Contrib.Extensions;
 using MySql.Data.MySqlClient;
@@ -28,7 +27,7 @@ namespace osu.ElasticIndexer
 
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
-                var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+                var mode = HighScore.GetRulesetId<T>();
 
                 dbConnection.Open();
 
@@ -39,7 +38,7 @@ namespace osu.ElasticIndexer
 
         public static List<T> FetchByScoreIds<T>(List<ulong> scoreIds) where T : HighScore
         {
-            var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
+            var table = Model.GetTableName<T>();
 
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
@@ -68,7 +67,7 @@ namespace osu.ElasticIndexer
         {
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
-                var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+                var mode = HighScore.GetRulesetId<T>();
 
                 dbConnection.Open();
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -53,13 +53,13 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static ulong? GetFirstPendingQueueId(int mode)
+        public static ulong? GetLastProcessedQueueId(int mode)
         {
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
                 dbConnection.Open();
 
-                const string query = "select MIN(queue_id) from score_process_queue where mode = @mode";
+                const string query = "SELECT MAX(queue_id) FROM score_process_queue WHERE status = 2 AND mode = @mode";
                 return dbConnection.QuerySingleOrDefault<ulong>(query, new { mode });
             }
         }
@@ -72,7 +72,7 @@ namespace osu.ElasticIndexer
 
                 dbConnection.Open();
 
-                const string query = "update score_process_queue set status = 1 where queue_id >= @from and mode = @mode";
+                const string query = "UPDATE score_process_queue SET status = 1 WHERE queue_id > @from AND mode = @mode";
                 dbConnection.Execute(query, new { from, mode });
             }
         }


### PR DESCRIPTION
- Deleting is only supported when using the queue.
- The indexed document id has been changed to `score_id` instead of the previous computed value since it can't be computed from a non-existent record. This means the index needs to be recreated.
- `crawl` options has been renamed to `rebuild`
- `rebuild=1` cannot be used at the same time as `watch=1` (only the queue-based processor can watch)
- rebuilding an (new) index will save the current queue position; the queue-based processor will rollback to this position when the index alias gets switched over.
