### PR TITLE
Remove _source from score index

### DIFF
--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -67,6 +67,8 @@ namespace osu.ElasticIndexer
             assertOptionsCompatible();
         }
 
+        public static int BufferSize { get; private set; } = 5;
+
         // same value as elasticsearch-net
         public static TimeSpan BulkAllBackOffTimeDefault = TimeSpan.FromMinutes(1);
 
@@ -82,7 +84,6 @@ namespace osu.ElasticIndexer
 
         public static bool IsNew { get; private set; }
 
-
         public static bool IsRebuild { get; private set; }
 
         public static bool IsWatching { get; private set; }
@@ -92,8 +93,6 @@ namespace osu.ElasticIndexer
         public static int PollingInterval { get; private set; } = 10000;
 
         public static string Prefix { get; private set; }
-
-        public static int BufferSize { get; private set; } = 5;
 
         public static ulong? ResumeFrom { get; private set; }
 

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -110,8 +110,14 @@ namespace osu.ElasticIndexer
             if (IsRebuild && IsWatching)
                 throw new Exception("watch mode cannot be used with index rebuilding.");
 
-            if (!IsRebuild && string.IsNullOrWhiteSpace(Version))
-                throw new Exception("queue processing requires a version to be specified.");
+            if (!IsRebuild)
+            {
+                if (string.IsNullOrWhiteSpace(Version))
+                    throw new Exception("queue processing requires a version to be specified.");
+
+                if (IsNew)
+                    throw new Exception("creating a new index is not supported with queue processing.");
+            }
 
             if (IsPrepMode)
             {

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -58,7 +58,7 @@ namespace osu.ElasticIndexer
             IsWatching = parseBool("watch");
 
             Prefix = config["elasticsearch:prefix"];
-            Version = config["version"];
+            Schema = config["schema"];
 
             ElasticsearchHost = config["elasticsearch:host"];
             ElasticsearchPrefix = config["elasticsearch:prefix"];
@@ -103,7 +103,7 @@ namespace osu.ElasticIndexer
 
         public static bool UseDocker { get; private set; }
 
-        public static string Version { get; private set; }
+        public static string Schema { get; private set; }
 
         private static void assertOptionsCompatible()
         {
@@ -112,8 +112,8 @@ namespace osu.ElasticIndexer
 
             if (!IsRebuild)
             {
-                if (string.IsNullOrWhiteSpace(Version))
-                    throw new Exception("queue processing requires a version to be specified.");
+                if (string.IsNullOrWhiteSpace(Schema))
+                    throw new Exception("queue processing requires a schema version to be specified.");
 
                 if (IsNew)
                     throw new Exception("creating a new index is not supported with queue processing.");
@@ -124,8 +124,8 @@ namespace osu.ElasticIndexer
                 if (!IsRebuild)
                     throw new Exception("prep mode is only valid while rebuilding.");
 
-                if (string.IsNullOrWhiteSpace(Version))
-                    throw new Exception("rebuilding in prep mode requires a version.");
+                if (string.IsNullOrWhiteSpace(Schema))
+                    throw new Exception("rebuilding in prep mode requires a schema version.");
 
                 if (ResumeFrom.HasValue)
                     throw new Exception("resume_from cannot be used in this mode.");

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -57,6 +57,7 @@ namespace osu.ElasticIndexer
             IsRebuild = parseBool("rebuild");
             IsWatching = parseBool("watch");
             Prefix = config["elasticsearch:prefix"];
+            Version = config["version"];
 
             ElasticsearchHost = config["elasticsearch:host"];
             ElasticsearchPrefix = config["elasticsearch:prefix"];
@@ -105,6 +106,8 @@ namespace osu.ElasticIndexer
 
         public static bool UseDocker { get; private set; }
 
+        public static string Version { get; private set; }
+
         private static bool IsPrepMode { get; set; }
 
         private static void assertOptionsCompatible()
@@ -114,6 +117,9 @@ namespace osu.ElasticIndexer
 
             if (IsPrepMode)
             {
+                if (IsRebuild && string.IsNullOrWhiteSpace(Version))
+                    throw new Exception("rebuilding in prep mode requires a version.");
+
                 if (ResumeFrom.HasValue)
                     throw new Exception("resume_from cannot be used in this mode.");
 

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -84,7 +84,7 @@ namespace osu.ElasticIndexer
 
         public static string ElasticsearchPrefix { get; private set; }
 
-        public static bool IsNew { get; private set; }
+        public static bool IsNew { get; set; }
 
         public static bool IsPrepMode { get; private set; }
 

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -53,7 +53,7 @@ namespace osu.ElasticIndexer
 
             ConnectionString = config.GetConnectionString("osu");
             IsNew = parseBool("new");
-            IsUsingQueue = !parseBool("crawl");
+            IsRebuild = parseBool("rebuild");
             IsWatching = parseBool("watch");
             Prefix = config["elasticsearch:prefix"];
 
@@ -82,9 +82,8 @@ namespace osu.ElasticIndexer
 
         public static bool IsNew { get; private set; }
 
-        public static bool IsRebuild { get { return !IsUsingQueue; } }
 
-        public static bool IsUsingQueue { get; private set; }
+        public static bool IsRebuild { get; private set; }
 
         public static bool IsWatching { get; private set; }
 

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -64,6 +64,8 @@ namespace osu.ElasticIndexer
 
             UseDocker = parseBool("docker");
 
+            IsPrepMode = parseBool("prep");
+
             assertOptionsCompatible();
         }
 
@@ -84,6 +86,8 @@ namespace osu.ElasticIndexer
 
         public static bool IsNew { get; private set; }
 
+        public static bool IsPrepMode { get; private set; }
+
         public static bool IsRebuild { get; private set; }
 
         public static bool IsWatching { get; private set; }
@@ -102,6 +106,12 @@ namespace osu.ElasticIndexer
         {
             if (IsRebuild && IsWatching)
                 throw new Exception("watch mode cannot be used with index rebuilding.");
+
+            if (IsPrepMode && ResumeFrom.HasValue)
+                    throw new Exception("resume_from cannot be used in this mode.");
+
+            if (IsPrepMode && IsNew && !IsRebuild)
+                throw new Exception("cannot use prep mode with creating a new index and not rebuilding.");
         }
 
         private static bool parseBool(string key)

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -63,6 +63,8 @@ namespace osu.ElasticIndexer
             ELASTIC_CLIENT = new ElasticClient(new ConnectionSettings(new Uri(ElasticsearchHost)));
 
             UseDocker = Environment.GetEnvironmentVariable("DOCKER")?.Contains("1") ?? false;
+
+            assertOptionsCompatible();
         }
 
         // same value as elasticsearch-net
@@ -80,6 +82,8 @@ namespace osu.ElasticIndexer
 
         public static bool IsNew { get; private set; }
 
+        public static bool IsRebuild { get { return !IsUsingQueue; } }
+
         public static bool IsUsingQueue { get; private set; }
 
         public static bool IsWatching { get; private set; }
@@ -95,6 +99,12 @@ namespace osu.ElasticIndexer
         public static ulong? ResumeFrom { get; private set; }
 
         public static bool UseDocker { get; private set; }
+
+        private static void assertOptionsCompatible()
+        {
+            if (IsRebuild && IsWatching)
+                throw new Exception("watch mode cannot be used with index rebuilding.");
+        }
 
         private static bool parseBool(string key)
         {

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -62,7 +62,7 @@ namespace osu.ElasticIndexer
 
             ELASTIC_CLIENT = new ElasticClient(new ConnectionSettings(new Uri(ElasticsearchHost)));
 
-            UseDocker = Environment.GetEnvironmentVariable("DOCKER")?.Contains("1") ?? false;
+            UseDocker = parseBool("docker");
 
             assertOptionsCompatible();
         }

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -43,7 +43,7 @@ namespace osu.ElasticIndexer
                 BufferSize = int.Parse(config["buffer_size"]);
 
             if (!string.IsNullOrEmpty(config["resume_from"]))
-                ResumeFrom = long.Parse(config["resume_from"]);
+                ResumeFrom = ulong.Parse(config["resume_from"]);
 
             if (!string.IsNullOrEmpty(config["polling_interval"]))
                 PollingInterval = int.Parse(config["polling_interval"]);
@@ -92,7 +92,7 @@ namespace osu.ElasticIndexer
 
         public static int BufferSize { get; private set; } = 5;
 
-        public static long? ResumeFrom { get; private set; }
+        public static ulong? ResumeFrom { get; private set; }
 
         public static bool UseDocker { get; private set; }
 

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -54,8 +54,10 @@ namespace osu.ElasticIndexer
 
             ConnectionString = config.GetConnectionString("osu");
             IsNew = parseBool("new");
-            IsRebuild = parseBool("rebuild");
+            IsPrepMode = parseBool("prep");
+            IsRebuild = IsPrepMode || parseBool("rebuild");
             IsWatching = parseBool("watch");
+
             Prefix = config["elasticsearch:prefix"];
             Version = config["version"];
 
@@ -65,8 +67,6 @@ namespace osu.ElasticIndexer
             ELASTIC_CLIENT = new ElasticClient(new ConnectionSettings(new Uri(ElasticsearchHost)));
 
             UseDocker = parseBool("docker");
-
-            IsPrepMode = parseBool("prep");
 
             assertOptionsCompatible();
         }

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -28,7 +28,7 @@ namespace osu.ElasticIndexer
             this.index = index;
         }
 
-        internal void Enqueue(List<T> add = null, List<string> remove = null) => readBuffer.Add(new DispatcherQueueItem<T>(add, remove));
+        internal void Enqueue(List<T> add = null, List<T> remove = null) => readBuffer.Add(new DispatcherQueueItem<T>(add, remove));
         internal void EnqueueEnd() => readBuffer.CompleteAdding();
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace osu.ElasticIndexer
                     var bulkDescriptor = new BulkDescriptor()
                         .Index(index)
                         .IndexMany(chunk.IndexItems)
-                        .DeleteMany(chunk.DeleteIds);
+                        .DeleteMany(chunk.DeleteItems);
                     var response = elasticClient.Bulk(bulkDescriptor);
 
                     bool retry;

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -12,7 +12,7 @@ namespace osu.ElasticIndexer
 {
     internal class BulkIndexingDispatcher<T> where T : HighScore
     {
-        internal event EventHandler<ulong> BatchWithLastIdCompleted = delegate { };
+        internal event EventHandler<ulong> BatchWithLastIdCompleted;
 
         // use shared instance to avoid socket leakage.
         private readonly ElasticClient elasticClient = AppSettings.ELASTIC_CLIENT;
@@ -66,7 +66,7 @@ namespace osu.ElasticIndexer
                 }
 
                 if (success)
-                    BatchWithLastIdCompleted(this, chunk.ItemsToIndex.Last().ScoreId);
+                    BatchWithLastIdCompleted?.Invoke(this, chunk.ItemsToIndex.Last().ScoreId);
             });
         }
 

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -28,7 +28,7 @@ namespace osu.ElasticIndexer
             this.index = index;
         }
 
-        internal void Enqueue(List<T> add = null, List<long> remove = null) => readBuffer.Add(new DispatcherQueueItem<T>(add, remove) );
+        internal void Enqueue(List<T> add = null, List<string> remove = null) => readBuffer.Add(new DispatcherQueueItem<T>(add, remove));
         internal void EnqueueEnd() => readBuffer.CompleteAdding();
 
         /// <summary>
@@ -51,10 +51,14 @@ namespace osu.ElasticIndexer
 
                 while (true)
                 {
+                    var bulkDescriptor = new BulkDescriptor()
+                        .Index(index)
+                        .IndexMany(chunk.IndexItems)
+                        .DeleteMany(chunk.DeleteIds);
+                    var response = elasticClient.Bulk(bulkDescriptor);
+
                     bool retry;
-                    // TODO: do index or delete only, not both.
-                    (success, retry) = bulkIndex(chunk.IndexItems);
-                    (success, retry) = delete(chunk.DeleteScoreIds);
+                    (success, retry) = retryOnResponse(response, chunk);
 
                     if (!retry) break;
 
@@ -77,39 +81,12 @@ namespace osu.ElasticIndexer
             IndexMeta.Refresh();
         }
 
-        private (bool success, bool retry) bulkIndex(List<T> items)
-        {
-            if (items == null) return (success: true, retry: false);
-
-            var bulkDescriptor = new BulkDescriptor().Index(index).IndexMany(items);
-            var response = elasticClient.Bulk(bulkDescriptor);
-
-            return retryOnResponse(response, items);
-        }
-
-        private (bool success, bool retry) delete(List<long> scoreIds)
-        {
-            if (scoreIds == null) return (success: true, retry: false);
-
-            var deleteResponse = elasticClient.DeleteByQuery<T>(d => d
-                .Index(index)
-                .Query(q => q
-                    .Terms(t => t
-                        .Field(s => s.ScoreId)
-                        .Terms(scoreIds)
-                    )
-                )
-            );
-
-            return (success: true, retry: false);
-        }
-
-        private (bool success, bool retry) retryOnResponse(IBulkResponse response, List<T> items)
+        private (bool success, bool retry) retryOnResponse(IBulkResponse response, DispatcherQueueItem<T> queued)
         {
             // Elasticsearch bulk thread pool is full.
             if (response.ItemsWithErrors.Any(item => item.Status == 429 || item.Error.Type == "es_rejected_execution_exception"))
             {
-                Console.WriteLine($"Server returned 429, re-queued chunk with lastId {items.Last().CursorValue}");
+                Console.WriteLine($"Server returned 429, re-queued chunk with lastId {queued.IndexItems.Last().CursorValue}");
                 return (success: false, retry: true);
             }
 

--- a/osu.ElasticIndexer/BulkIndexingDispatcher.cs
+++ b/osu.ElasticIndexer/BulkIndexingDispatcher.cs
@@ -53,8 +53,8 @@ namespace osu.ElasticIndexer
                 {
                     var bulkDescriptor = new BulkDescriptor()
                         .Index(index)
-                        .IndexMany(chunk.IndexItems)
-                        .DeleteMany(chunk.DeleteItems);
+                        .IndexMany(chunk.ItemsToIndex)
+                        .DeleteMany(chunk.ItemsToDelete);
                     var response = elasticClient.Bulk(bulkDescriptor);
 
                     bool retry;
@@ -66,7 +66,7 @@ namespace osu.ElasticIndexer
                 }
 
                 if (success)
-                    BatchWithLastIdCompleted(this, chunk.IndexItems.Last().ScoreId);
+                    BatchWithLastIdCompleted(this, chunk.ItemsToIndex.Last().ScoreId);
             });
         }
 
@@ -75,7 +75,7 @@ namespace osu.ElasticIndexer
             // Elasticsearch bulk thread pool is full.
             if (response.ItemsWithErrors.Any(item => item.Status == 429 || item.Error.Type == "es_rejected_execution_exception"))
             {
-                Console.WriteLine($"Server returned 429, re-queued chunk with lastId {queued.IndexItems.Last().CursorValue}");
+                Console.WriteLine($"Server returned 429, re-queued chunk with lastId {queued.ItemsToIndex.Last().CursorValue}");
                 return (success: false, retry: true);
             }
 

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -14,8 +14,8 @@ namespace osu.ElasticIndexer
         public IEnumerable<T> ItemsToIndex { get; private set; }
 
         public DispatcherQueueItem(IEnumerable<T> add, IEnumerable<T> remove) {
-            ItemsToIndex = add ?? empty_list;
-            ItemsToDelete = remove ?? empty_list;
+            ItemsToIndex = add ?? Enumerable.Empty<T>();
+            ItemsToDelete = remove ?? Enumerable.Empty<T>();
         }
     }
 }

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -2,21 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.ElasticIndexer
 {
     public class DispatcherQueueItem<T> where T : HighScore
     {
-        private static readonly List<T> EmptyList = new List<T>(0);
+        private static readonly List<T> empty_list = new List<T>(0);
 
         public List<T> IndexItems { get; private set; }
 
         public List<T> DeleteItems { get; private set; }
 
         public DispatcherQueueItem(List<T> index, List<T> delete) {
-            IndexItems = index ?? EmptyList;
-            DeleteItems = delete ?? EmptyList;
+            IndexItems = index ?? empty_list;
+            DeleteItems = delete ?? empty_list;
         }
     }
 }

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -8,15 +8,15 @@ namespace osu.ElasticIndexer
 {
     public class DispatcherQueueItem<T> where T : HighScore
     {
-        private static readonly List<string> EmptyDeleteList = new List<string>(0);
+        private static readonly List<T> EmptyList = new List<T>(0);
 
         public List<T> IndexItems { get; private set; }
 
-        public List<string> DeleteIds { get; private set; }
+        public List<T> DeleteItems { get; private set; }
 
-        public DispatcherQueueItem(List<T> index, List<string> delete = null) {
-            IndexItems = index.Where(x => x.ShouldIndex).ToList(); // this should probably not go here?
-            DeleteIds = delete ?? EmptyDeleteList;
+        public DispatcherQueueItem(List<T> index, List<T> delete) {
+            IndexItems = index ?? EmptyList;
+            DeleteItems = delete ?? EmptyList;
         }
     }
 }

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -8,8 +8,6 @@ namespace osu.ElasticIndexer
 {
     public class DispatcherQueueItem<T> where T : HighScore
     {
-        private static readonly IEnumerable<T> empty_list = new ReadOnlyCollection<T>(new List<T>(0));
-
         public IEnumerable<T> ItemsToDelete { get; private set; }
         public IEnumerable<T> ItemsToIndex { get; private set; }
 

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -2,20 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace osu.ElasticIndexer
 {
     public class DispatcherQueueItem<T> where T : HighScore
     {
-        private static readonly List<T> empty_list = new List<T>(0);
+        private static readonly IEnumerable<T> empty_list = new ReadOnlyCollection<T>(new List<T>(0));
 
-        public List<T> IndexItems { get; private set; }
+        public IEnumerable<T> ItemsToDelete { get; private set; }
+        public IEnumerable<T> ItemsToIndex { get; private set; }
 
-        public List<T> DeleteItems { get; private set; }
-
-        public DispatcherQueueItem(List<T> index, List<T> delete) {
-            IndexItems = index ?? empty_list;
-            DeleteItems = delete ?? empty_list;
+        public DispatcherQueueItem(IEnumerable<T> add, IEnumerable<T> remove) {
+            ItemsToIndex = add ?? empty_list;
+            ItemsToDelete = remove ?? empty_list;
         }
     }
 }

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -2,18 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace osu.ElasticIndexer
 {
     public class DispatcherQueueItem<T> where T : HighScore
     {
+        private static readonly List<string> EmptyDeleteList = new List<string>(0);
+
         public List<T> IndexItems { get; private set; }
 
-        public List<long> DeleteScoreIds { get; private set; }
+        public List<string> DeleteIds { get; private set; }
 
-        public DispatcherQueueItem(List<T> index, List<long> delete = null) {
-            IndexItems = index;
-            DeleteScoreIds = delete;
+        public DispatcherQueueItem(List<T> index, List<string> delete = null) {
+            IndexItems = index.Where(x => x.ShouldIndex).ToList(); // this should probably not go here?
+            DeleteIds = delete ?? EmptyDeleteList;
         }
     }
 }

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.ElasticIndexer
+{
+    public class DispatcherQueueItem<T> where T : HighScore
+    {
+        public List<T> IndexItems { get; private set; }
+        public List<T> DeleteItems { get; private set; }
+
+        public DispatcherQueueItem(List<T> index, List<T> delete = null) {
+            IndexItems = index;
+            DeleteItems = delete;
+        }
+    }
+}

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace osu.ElasticIndexer
 {

--- a/osu.ElasticIndexer/DispatcherQueueItem.cs
+++ b/osu.ElasticIndexer/DispatcherQueueItem.cs
@@ -8,11 +8,12 @@ namespace osu.ElasticIndexer
     public class DispatcherQueueItem<T> where T : HighScore
     {
         public List<T> IndexItems { get; private set; }
-        public List<T> DeleteItems { get; private set; }
 
-        public DispatcherQueueItem(List<T> index, List<T> delete = null) {
+        public List<long> DeleteScoreIds { get; private set; }
+
+        public DispatcherQueueItem(List<T> index, List<long> delete = null) {
             IndexItems = index;
-            DeleteItems = delete;
+            DeleteScoreIds = delete;
         }
     }
 }

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Dapper.Contrib.Extensions;
 using Nest;
 
@@ -130,6 +131,11 @@ namespace osu.ElasticIndexer
             }
 
             return mods.Values.ToList();
+        }
+
+        public static int GetRulesetId<T>() where T : HighScore
+        {
+            return typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
         }
     }
 }

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -24,7 +24,7 @@ namespace osu.ElasticIndexer
         public string Id => $"{UserId}-{BeatmapId}-{EnabledMods}";
 
         [Number(NumberType.Long, Name = "score_id")]
-        public uint ScoreId { get; set; }
+        public long ScoreId { get; set; }
 
         [Number(NumberType.Long, Name = "beatmap_id")]
         public uint BeatmapId { get; set; }

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -12,7 +12,7 @@ using Nest;
 namespace osu.ElasticIndexer
 {
     [CursorColumn("score_id")]
-    [ElasticsearchType(Name = "high_score", IdProperty = nameof(ScoreId))]
+    [ElasticsearchType(Name = "_doc", IdProperty = nameof(ScoreId))]
     public abstract class HighScore : Model
     {
         [Computed]

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -15,7 +15,7 @@ namespace osu.ElasticIndexer
     {
         [Computed]
         [Ignore]
-        public override long CursorValue => (long) ScoreId;
+        public override ulong CursorValue => ScoreId;
 
         [Computed]
         [Ignore]

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -15,7 +15,7 @@ namespace osu.ElasticIndexer
     {
         [Computed]
         [Ignore]
-        public override long CursorValue => ScoreId;
+        public override long CursorValue => (long) ScoreId;
 
         [Computed]
         [Ignore]
@@ -28,7 +28,7 @@ namespace osu.ElasticIndexer
         public string Id => $"{UserId}-{BeatmapId}-{EnabledMods}";
 
         [Number(NumberType.Long, Name = "score_id")]
-        public long ScoreId { get; set; }
+        public ulong ScoreId { get; set; }
 
         [Number(NumberType.Long, Name = "beatmap_id")]
         public uint BeatmapId { get; set; }

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Dapper.Contrib.Extensions;
@@ -136,6 +137,13 @@ namespace osu.ElasticIndexer
         public static int GetRulesetId<T>() where T : HighScore
         {
             return typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+        }
+
+        public static Type GetTypeFromModeString(string mode)
+        {
+            var className = $"{typeof(HighScore).Namespace}.HighScore{CultureInfo.InvariantCulture.TextInfo.ToTitleCase(mode)}";
+
+            return Type.GetType(className, true);
         }
     }
 }

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -10,12 +10,16 @@ using Nest;
 namespace osu.ElasticIndexer
 {
     [CursorColumn("score_id")]
-    [ElasticsearchType(Name = "high_score", IdProperty = nameof(Id))]
+    [ElasticsearchType(Name = "high_score", IdProperty = nameof(ScoreId))]
     public abstract class HighScore : Model
     {
         [Computed]
         [Ignore]
         public override long CursorValue => ScoreId;
+
+        [Computed]
+        [Ignore]
+        public bool ShouldIndex => Pp > 0;
 
         // Properties ordered in the order they appear in the table.
 

--- a/osu.ElasticIndexer/HighScore.cs
+++ b/osu.ElasticIndexer/HighScore.cs
@@ -19,13 +19,9 @@ namespace osu.ElasticIndexer
 
         [Computed]
         [Ignore]
-        public bool ShouldIndex => Pp > 0;
+        public bool ShouldIndex => Pp.HasValue;
 
         // Properties ordered in the order they appear in the table.
-
-        [Computed]
-        [Ignore]
-        public string Id => $"{UserId}-{BeatmapId}-{EnabledMods}";
 
         [Number(NumberType.Long, Name = "score_id")]
         public ulong ScoreId { get; set; }
@@ -77,7 +73,7 @@ namespace osu.ElasticIndexer
         public DateTimeOffset Date { get; set; }
 
         [Number(NumberType.Float, Name = "pp")]
-        public float Pp { get; set; }
+        public float? Pp { get; set; }
 
         [Boolean(Name = "replay")]
         public bool Replay { get; set; }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -20,7 +20,7 @@ namespace osu.ElasticIndexer
         public string Suffix { get; set; }
 
         // use shared instance to avoid socket leakage.
-        private readonly ElasticClient elasticClient = AppSettings.ELASTIC_CLIENT;
+        private readonly ElasticClient elasticClient = IndexMeta.CLIENT;
 
         private BulkIndexingDispatcher<T> dispatcher;
 

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -29,8 +29,6 @@ namespace osu.ElasticIndexer
             if (!checkIfReady()) return;
 
             var initial = initialize();
-            if (initial == null) return;
-
             var index = initial.Index;
             var metaVersion = AppSettings.IsPrepMode ? null : AppSettings.Version;
 
@@ -243,8 +241,7 @@ namespace osu.ElasticIndexer
 
                 if (indexMeta.Version != AppSettings.Version)
                     // A switchover is probably happening, so signal that this mode should be skipped.
-                    Console.WriteLine($"`{Name}` found version {indexMeta.Version}, expecting {AppSettings.Version}");
-                    return null;
+                    throw new VersionMismatchException($"`{Name}` found version {indexMeta.Version}, expecting {AppSettings.Version}");
             }
 
             indexMeta.LastId = ResumeFrom ?? indexMeta.LastId;

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -55,7 +55,7 @@ namespace osu.ElasticIndexer
 
                 // when preparing for schema changes, the alias update
                 // should be done by process waiting for the ready signal.
-                if (AppSettings.IsPrepMode)
+                if (AppSettings.IsPrep.Contains(typeof(T)))
                     IndexMeta.MarkAsReady(index);
                 else
                     updateAlias(Name, index);
@@ -92,14 +92,16 @@ namespace osu.ElasticIndexer
 
         private bool checkIfReady()
         {
-            if (!AppSettings.IsPrepMode || AppSettings.IsRebuild)
+            if (!AppSettings.IsPrep.Contains(typeof(T)) || AppSettings.IsRebuild)
                 return true;
 
+            Console.WriteLine();
             var indexMeta = IndexMeta.GetPrepIndex(Name);
 
             if (indexMeta == null)
             {
-                Console.WriteLine($"{Name} is not ready");
+
+                Console.WriteLine($"{Name} is not ready...");
                 return false;
             }
             else
@@ -108,6 +110,8 @@ namespace osu.ElasticIndexer
                 // update alias and go
                 var index = findOrCreateIndex(Name);
                 updateAlias(Name, index);
+                AppSettings.IsPrep.Remove(typeof(T));
+
                 return true;
             }
         }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -75,7 +75,10 @@ namespace osu.ElasticIndexer
             {
                 if (!(ex is InvalidOperationException)) return false;
 
-                Console.WriteLine(ex.Message);
+                Console.Error.WriteLine(ex.Message);
+                if (ex.InnerException != null)
+                    Console.Error.WriteLine(ex.InnerException.Message);
+
                 return true;
             }
 

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -98,7 +98,10 @@ namespace osu.ElasticIndexer
                                 {
                                     var scoreIds = chunk.Select(x => x.ScoreId).ToList();
                                     var scores = ScoreProcessQueue.FetchByScoreIds<T>(scoreIds);
-                                    var removedScores = scoreIds.Except(scores.Select(x => x.ScoreId)).ToList();
+                                    var removedScores = scoreIds
+                                        .Except(scores.Select(x => x.ScoreId))
+                                        .Select(x => x.ToString())
+                                        .ToList();
                                     Console.WriteLine($"Got {chunk.Count} items from queue, found {scores.Count} matching scores, {removedScores.Count} missing scores");
 
                                     dispatcher.Enqueue(add: scores, remove: removedScores);
@@ -109,7 +112,7 @@ namespace osu.ElasticIndexer
                             else
                             {
                                 Console.WriteLine("Crawling records...");
-                                var chunks = Model.Chunk<T>("pp is not null", AppSettings.ChunkSize, resumeFrom);
+                                var chunks = Model.Chunk<T>(AppSettings.ChunkSize, resumeFrom);
                                 foreach (var chunk in chunks)
                                 {
                                     dispatcher.Enqueue(chunk);

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -26,6 +26,8 @@ namespace osu.ElasticIndexer
 
         public void Run()
         {
+            if (!checkIfReady()) return;
+
             var initial = initialize();
             var index = initial.Index;
 
@@ -78,6 +80,28 @@ namespace osu.ElasticIndexer
                     ResetQueueTo = initial.ResetQueueTo,
                     UpdatedAt = DateTimeOffset.UtcNow
                 });
+            }
+        }
+
+        private bool checkIfReady()
+        {
+            if (!AppSettings.IsPrepMode) return true;
+            if (AppSettings.IsRebuild) return true;
+
+            var indexMeta = IndexMeta.GetPrepIndex(Name);
+
+            if (indexMeta == null)
+            {
+                Console.WriteLine($"{Name} is not ready");
+                return false;
+            }
+            else
+            {
+                Console.WriteLine($"{Name} is ready");
+                // update alias and go
+                var index = findOrCreateIndex(Name);
+                updateAlias(Name, index);
+                return true;
             }
         }
 

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -32,6 +32,7 @@ namespace osu.ElasticIndexer
 
             var initial = initialize();
             var index = initial.Index;
+            var metaVersion = isPreparing ? null : AppSettings.Version;
 
             var indexCompletedArgs = new IndexCompletedArgs
             {
@@ -41,6 +42,7 @@ namespace osu.ElasticIndexer
             };
 
             dispatcher = new BulkIndexingDispatcher<T>(index);
+
             if (AppSettings.IsRebuild)
                 dispatcher.BatchWithLastIdCompleted += handleBatchWithLastIdCompleted;
 
@@ -87,7 +89,8 @@ namespace osu.ElasticIndexer
                     Alias = Name,
                     LastId = lastId,
                     ResetQueueTo = initial.ResetQueueTo,
-                    UpdatedAt = DateTimeOffset.UtcNow
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                    Version = metaVersion
                 });
             }
         }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -98,9 +98,10 @@ namespace osu.ElasticIndexer
                                 {
                                     var scoreIds = chunk.Select(x => x.ScoreId).ToList();
                                     var scores = ScoreProcessQueue.FetchByScoreIds<T>(scoreIds);
-                                    Console.WriteLine($"Got {chunk.Count} items from queue, found {scores.Count} matching scores");
+                                    var removedScores = scoreIds.Except(scores.Select(x => x.ScoreId)).ToList();
+                                    Console.WriteLine($"Got {chunk.Count} items from queue, found {scores.Count} matching scores, {removedScores.Count} missing scores");
 
-                                    dispatcher.Enqueue(scores);
+                                    dispatcher.Enqueue(add: scores, remove: removedScores);
                                     ScoreProcessQueue.CompleteQueued<T>(scoreIds);
                                     count += scores.Count;
                                 }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -234,6 +234,9 @@ namespace osu.ElasticIndexer
                 Index = index,
             };
 
+            if (!AppSettings.IsRebuild && string.IsNullOrWhiteSpace(indexMeta.Version))
+                throw new Exception("FATAL ERROR: attempting to process queue without a known version.");
+
             indexMeta.LastId = ResumeFrom ?? indexMeta.LastId;
 
             Console.WriteLine();

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -143,7 +143,7 @@ namespace osu.ElasticIndexer
                                     Console.WriteLine($"Got {chunk.Count} items from queue, found {scores.Count} matching scores, {removedScores.Count} missing scores");
 
                                     dispatcher.Enqueue(add: scores, remove: removedScores);
-                                    ScoreProcessQueue.CompleteQueued<T>(chunk);
+                                    ScoreProcessQueue.CompleteQueued(chunk);
                                     count += scores.Count;
                                 }
                             }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -189,7 +189,7 @@ namespace osu.ElasticIndexer
                 : IndexMeta.GetByAliasForCurrentVersion(name)
             ).ToList();
 
-            string index;
+            string index = null;
 
             if (!AppSettings.IsNew)
             {
@@ -213,6 +213,9 @@ namespace osu.ElasticIndexer
                     return (index, aliased: false);
                 }
             }
+
+            if (!AppSettings.IsRebuild && index == null)
+                throw new Exception("no existing index found");
 
             // 3. Not aliased and no tracking information; likely starting from scratch
             var suffix = Suffix ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -205,7 +205,7 @@ namespace osu.ElasticIndexer
                 if (indexMeta.ResetQueueTo.HasValue) return;
 
                 var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
-                indexMeta.ResetQueueTo = ScoreProcessQueue.GetFirstPendingQueueId(mode);
+                indexMeta.ResetQueueTo = ScoreProcessQueue.GetLastProcessedQueueId(mode);
             }
             else
             {

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -24,6 +24,8 @@ namespace osu.ElasticIndexer
 
         private BulkIndexingDispatcher<T> dispatcher;
 
+        private bool isPreparing => AppSettings.IsPrep.Contains(typeof(T));
+
         public void Run()
         {
             if (!checkIfReady()) return;
@@ -55,7 +57,7 @@ namespace osu.ElasticIndexer
 
                 // when preparing for schema changes, the alias update
                 // should be done by process waiting for the ready signal.
-                if (AppSettings.IsPrep.Contains(typeof(T)))
+                if (isPreparing)
                     IndexMeta.MarkAsReady(index);
                 else
                     updateAlias(Name, index);
@@ -92,11 +94,11 @@ namespace osu.ElasticIndexer
 
         private bool checkIfReady()
         {
-            if (!AppSettings.IsPrep.Contains(typeof(T)) || AppSettings.IsRebuild)
+            if (AppSettings.IsRebuild)
                 return true;
 
             Console.WriteLine();
-            var indexMeta = IndexMeta.GetPrepIndex(Name);
+            var indexMeta = IndexMeta.GetByAliasForCurrentVersion(Name);
 
             if (indexMeta == null)
             {

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -17,7 +17,7 @@ namespace osu.ElasticIndexer
         public event EventHandler<IndexCompletedArgs> IndexCompleted = delegate { };
 
         public string Name { get; set; }
-        public long? ResumeFrom { get; set; }
+        public ulong? ResumeFrom { get; set; }
         public string Suffix { get; set; }
 
         // use shared instance to avoid socket leakage.
@@ -79,7 +79,7 @@ namespace osu.ElasticIndexer
         /// <param name="resumeFrom">The cursor value to resume from;
         /// use null to resume from the last known value.</param>
         /// <returns>The database reader task.</returns>
-        private Task<long> databaseReaderTask(long resumeFrom)
+        private Task<long> databaseReaderTask(ulong resumeFrom)
         {
             return Task.Factory.StartNew(() =>
                 {

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -108,7 +108,7 @@ namespace osu.ElasticIndexer
                     {
                         try
                         {
-                            if (AppSettings.IsUsingQueue)
+                            if (!AppSettings.IsRebuild)
                             {
                                 Console.WriteLine("Reading from queue...");
                                 var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
@@ -130,7 +130,7 @@ namespace osu.ElasticIndexer
                             }
                             else
                             {
-                                Console.WriteLine("Crawling records...");
+                                Console.WriteLine($"Rebuild from {resumeFrom}...");
                                 var chunks = Model.Chunk<T>(AppSettings.ChunkSize, resumeFrom);
                                 foreach (var chunk in chunks)
                                 {

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -100,8 +100,14 @@ namespace osu.ElasticIndexer
         /// <returns>true if ready; false, otherwise.</returns>
         private bool checkIfReady()
         {
-            if (AppSettings.IsRebuild || IndexMeta.GetByAliasForCurrentVersion(Name) != null)
+            if (AppSettings.IsRebuild) return true;
+
+            var indexMeta = IndexMeta.GetByAliasForCurrentVersion(Name);
+            if (indexMeta != null) {
+                // TODO: don't update on every start.
+                updateAlias(indexMeta.Alias, indexMeta.Index);
                 return true;
+            }
 
             Console.WriteLine($"`{Name}` for version {AppSettings.Version} is not ready...");
             return false;

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Data.Common;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Nest;
@@ -102,7 +101,7 @@ namespace osu.ElasticIndexer
                             if (!AppSettings.IsRebuild)
                             {
                                 Console.WriteLine("Reading from queue...");
-                                var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+                                var mode = HighScore.GetRulesetId<T>();
                                 var chunks = Model.Chunk<ScoreProcessQueue>($"status = 1 and mode = {mode}", AppSettings.ChunkSize);
                                 foreach (var chunk in chunks)
                                 {
@@ -220,7 +219,7 @@ namespace osu.ElasticIndexer
                 // so we likely want to preserve that value.
                 if (!indexMeta.ResetQueueTo.HasValue)
                 {
-                    var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+                    var mode = HighScore.GetRulesetId<T>();
                     indexMeta.ResetQueueTo = ScoreProcessQueue.GetLastProcessedQueueId(mode);
                 }
             }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -140,7 +140,7 @@ namespace osu.ElasticIndexer
                                     Console.WriteLine($"Got {chunk.Count} items from queue, found {scores.Count} matching scores, {removedScores.Count} missing scores");
 
                                     dispatcher.Enqueue(add: scores, remove: removedScores);
-                                    ScoreProcessQueue.CompleteQueued<T>(scoreIds);
+                                    ScoreProcessQueue.CompleteQueued<T>(chunk);
                                     count += scores.Count;
                                 }
                             }

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -234,16 +234,6 @@ namespace osu.ElasticIndexer
                 Index = index,
             };
 
-            if (!AppSettings.IsRebuild)
-            {
-                if (string.IsNullOrWhiteSpace(indexMeta.Version))
-                    throw new Exception("FATAL ERROR: attempting to process queue without a known version.");
-
-                if (indexMeta.Version != AppSettings.Version)
-                    // A switchover is probably happening, so signal that this mode should be skipped.
-                    throw new VersionMismatchException($"`{Name}` found version {indexMeta.Version}, expecting {AppSettings.Version}");
-            }
-
             indexMeta.LastId = ResumeFrom ?? indexMeta.LastId;
 
             Console.WriteLine();
@@ -262,6 +252,13 @@ namespace osu.ElasticIndexer
             }
             else
             {
+                if (string.IsNullOrWhiteSpace(indexMeta.Version))
+                    throw new Exception("FATAL ERROR: attempting to process queue without a known version.");
+
+                if (indexMeta.Version != AppSettings.Version)
+                    // A switchover is probably happening, so signal that this mode should be skipped.
+                    throw new VersionMismatchException($"`{Name}` found version {indexMeta.Version}, expecting {AppSettings.Version}");
+
                 if (!aliased)
                     updateAlias(Name, index);
 

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -202,13 +202,11 @@ namespace osu.ElasticIndexer
         {
             var index = findOrCreateIndex(Name);
             // look for any existing resume data.
-            var indexMeta = IndexMeta.GetByName(index);
-            if (indexMeta == null)
-                indexMeta = new IndexMeta
-                {
-                    Alias = Name,
-                    Index = index,
-                };
+            var indexMeta = IndexMeta.GetByName(index) ?? new IndexMeta
+            {
+                Alias = Name,
+                Index = index,
+            };
 
             indexMeta.LastId = ResumeFrom ?? indexMeta.LastId;
 

--- a/osu.ElasticIndexer/HighScoreIndexer.cs
+++ b/osu.ElasticIndexer/HighScoreIndexer.cs
@@ -30,7 +30,7 @@ namespace osu.ElasticIndexer
 
             var initial = initialize();
             var index = initial.Index;
-            var metaVersion = AppSettings.IsPrepMode ? null : AppSettings.Version;
+            var metaSchema = AppSettings.IsPrepMode ? null : AppSettings.Schema;
 
             var indexCompletedArgs = new IndexCompletedArgs
             {
@@ -89,7 +89,7 @@ namespace osu.ElasticIndexer
                     LastId = lastId,
                     ResetQueueTo = initial.ResetQueueTo,
                     UpdatedAt = DateTimeOffset.UtcNow,
-                    Version = metaVersion
+                    Schema = metaSchema
                 });
             }
         }
@@ -103,7 +103,7 @@ namespace osu.ElasticIndexer
             if (AppSettings.IsRebuild || IndexMeta.GetByAliasForCurrentVersion(Name).FirstOrDefault() != null)
                 return true;
 
-            Console.WriteLine($"`{Name}` for version {AppSettings.Version} is not ready...");
+            Console.WriteLine($"`{Name}` for version {AppSettings.Schema} is not ready...");
             return false;
         }
 
@@ -262,12 +262,12 @@ namespace osu.ElasticIndexer
             }
             else
             {
-                if (string.IsNullOrWhiteSpace(indexMeta.Version))
+                if (string.IsNullOrWhiteSpace(indexMeta.Schema))
                     throw new Exception("FATAL ERROR: attempting to process queue without a known version.");
 
-                if (indexMeta.Version != AppSettings.Version)
+                if (indexMeta.Schema != AppSettings.Schema)
                     // A switchover is probably happening, so signal that this mode should be skipped.
-                    throw new VersionMismatchException($"`{Name}` found version {indexMeta.Version}, expecting {AppSettings.Version}");
+                    throw new VersionMismatchException($"`{Name}` found version {indexMeta.Schema}, expecting {AppSettings.Schema}");
 
                 // process queue reset if any.
                 if (indexMeta.ResetQueueTo.HasValue)

--- a/osu.ElasticIndexer/IIndexer.cs
+++ b/osu.ElasticIndexer/IIndexer.cs
@@ -10,13 +10,6 @@ namespace osu.ElasticIndexer
         event EventHandler<IndexCompletedArgs> IndexCompleted;
 
         /// <summary>
-        /// The ID where the queue-based indexer should be forced to restart from on its next pass,
-        ///  after the index is rebuilt.
-        /// </summary>
-        /// <value></value>
-        ulong? FirstPendingQueueId { get; set; }
-
-        /// <summary>
         /// The index's name.
         /// </summary>
         string Name { get; set; }

--- a/osu.ElasticIndexer/IIndexer.cs
+++ b/osu.ElasticIndexer/IIndexer.cs
@@ -17,7 +17,7 @@ namespace osu.ElasticIndexer
         /// <summary>
         /// The ID from which to resume indexing from. If null, the most recent ID is used.
         /// </summary>
-        long? ResumeFrom { get; set; }
+        ulong? ResumeFrom { get; set; }
 
         /// <summary>
         /// The index suffix (generally a timestamp string).

--- a/osu.ElasticIndexer/IIndexer.cs
+++ b/osu.ElasticIndexer/IIndexer.cs
@@ -10,6 +10,13 @@ namespace osu.ElasticIndexer
         event EventHandler<IndexCompletedArgs> IndexCompleted;
 
         /// <summary>
+        /// The ID where the queue-based indexer should be forced to restart from on its next pass,
+        ///  after the index is rebuilt.
+        /// </summary>
+        /// <value></value>
+        ulong? FirstPendingQueueId { get; set; }
+
+        /// <summary>
         /// The index's name.
         /// </summary>
         string Name { get; set; }

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -1,3 +1,4 @@
+using System.Net;
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
@@ -33,6 +34,9 @@ namespace osu.ElasticIndexer
 
         [Number(NumberType.Long, Name = "last_id")]
         public ulong LastId { get; set; }
+
+        [Boolean(Name = "ready")]
+        public bool? Ready { get; set; }
 
         [Number(NumberType.Long, Name = "reset_queue_to")]
         public ulong? ResetQueueTo { get; set; }
@@ -76,6 +80,11 @@ namespace osu.ElasticIndexer
             );
 
             return response.Documents;
+        }
+
+        public static IndexMeta GetPrepIndex(string name)
+        {
+            return GetByAlias(name).Where(x => x.Ready == true).FirstOrDefault();
         }
     }
 }

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -34,14 +34,14 @@ namespace osu.ElasticIndexer
         [Number(NumberType.Long, Name = "last_id")]
         public ulong LastId { get; set; }
 
-        [Boolean(Name = "ready")]
-        public bool? Ready { get; set; }
-
         [Number(NumberType.Long, Name = "reset_queue_to")]
         public ulong? ResetQueueTo { get; set; }
 
         [Date(Name = "updated_at")]
         public DateTimeOffset UpdatedAt { get; set; }
+
+        [Text(Name = "version")]
+        public string Version { get; set; }
 
         public static ICreateIndexResponse CreateIndex()
         {
@@ -54,7 +54,7 @@ namespace osu.ElasticIndexer
 
         public static void MarkAsReady(string index)
         {
-            client.Update<IndexMeta, object>(index, d => d.Doc(new { Ready = true }));
+            client.Update<IndexMeta, object>(index, d => d.Doc(new { Version = AppSettings.Version }));
         }
 
         public static void Refresh()
@@ -86,9 +86,9 @@ namespace osu.ElasticIndexer
             return response.Documents;
         }
 
-        public static IndexMeta GetPrepIndex(string name)
+        public static IndexMeta GetByAliasForCurrentVersion(string name)
         {
-            return GetByAlias(name).Where(x => x.Ready == true).FirstOrDefault();
+            return GetByAlias(name).Where(x => x.Version == AppSettings.Version).FirstOrDefault();
         }
     }
 }

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -15,7 +15,7 @@ namespace osu.ElasticIndexer
             new ConnectionSettings(
                 new Uri(AppSettings.ElasticsearchHost)
             ).DefaultIndex($"{AppSettings.ElasticsearchPrefix}index_meta")
-            .ThrowExceptions(true)
+            .ThrowExceptions()
         );
 
         /// <summary>

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -11,7 +11,7 @@ namespace osu.ElasticIndexer
     [ElasticsearchType(Name = "index_meta", IdProperty = nameof(Index))]
     public class IndexMeta
     {
-        private static readonly ElasticClient client = new ElasticClient(
+        public static readonly ElasticClient CLIENT = new ElasticClient(
             new ConnectionSettings(
                 new Uri(AppSettings.ElasticsearchHost)
             ).DefaultIndex($"{AppSettings.ElasticsearchPrefix}index_meta")
@@ -45,7 +45,7 @@ namespace osu.ElasticIndexer
 
         public static ICreateIndexResponse CreateIndex()
         {
-            return client.CreateIndex($"{AppSettings.ElasticsearchPrefix}index_meta", c => c
+            return CLIENT.CreateIndex($"{AppSettings.ElasticsearchPrefix}index_meta", c => c
                 .Settings(s => s.NumberOfShards(1))
                 .Mappings(ms => ms.Map<IndexMeta>(m => m.AutoMap()))
                 .WaitForActiveShards("1")
@@ -55,22 +55,22 @@ namespace osu.ElasticIndexer
 
         public static void MarkAsReady(string index)
         {
-            client.Update<IndexMeta, object>(index, d => d.Doc(new { AppSettings.Schema }));
+            CLIENT.Update<IndexMeta, object>(index, d => d.Doc(new { AppSettings.Schema }));
         }
 
         public static void Refresh()
         {
-            client.Refresh($"{AppSettings.ElasticsearchPrefix}index_meta");
+            CLIENT.Refresh($"{AppSettings.ElasticsearchPrefix}index_meta");
         }
 
         public static void UpdateAsync(IndexMeta indexMeta)
         {
-            client.IndexDocumentAsync(indexMeta);
+            CLIENT.IndexDocumentAsync(indexMeta);
         }
 
         public static IndexMeta GetByName(string name)
         {
-            var response = client.Search<IndexMeta>(s => s
+            var response = CLIENT.Search<IndexMeta>(s => s
                 .Query(q => q.Ids(d => d.Values(name)))
             );
 
@@ -79,7 +79,7 @@ namespace osu.ElasticIndexer
 
         public static IEnumerable<IndexMeta> GetByAlias(string name)
         {
-            var response = client.Search<IndexMeta>(s => s
+            var response = CLIENT.Search<IndexMeta>(s => s
                 .Query(q => q.Term(d => d.Alias, name))
                 .Sort(sort => sort.Descending(p => p.UpdatedAt))
             );
@@ -89,7 +89,7 @@ namespace osu.ElasticIndexer
 
         public static IEnumerable<IndexMeta> GetByAliasForCurrentVersion(string name)
         {
-            var response = client.Search<IndexMeta>(s => s
+            var response = CLIENT.Search<IndexMeta>(s => s
                 .Query(q => q
                     .Term(t => t.Alias, name) && q
                     .Term(t => t.Schema, AppSettings.Schema)

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -86,7 +86,7 @@ namespace osu.ElasticIndexer
             return response.Documents;
         }
 
-        public static IndexMeta GetByAliasForCurrentVersion(string name)
+        public static IEnumerable<IndexMeta> GetByAliasForCurrentVersion(string name)
         {
             var response = client.Search<IndexMeta>(s => s
                 .Query(q => q
@@ -96,7 +96,7 @@ namespace osu.ElasticIndexer
                 .Sort(sort => sort.Descending(p => p.UpdatedAt))
             );
 
-            return response.Documents.FirstOrDefault();
+            return response.Documents;
         }
     }
 }

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -34,6 +34,9 @@ namespace osu.ElasticIndexer
         [Number(NumberType.Long, Name = "last_id")]
         public ulong LastId { get; set; }
 
+        [Number(NumberType.Long, Name = "reset_queue_to")]
+        public ulong? ResetQueueTo { get; set; }
+
         [Date(Name = "updated_at")]
         public DateTimeOffset UpdatedAt { get; set; }
 

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -15,8 +15,8 @@ namespace osu.ElasticIndexer
             new ConnectionSettings(
                 new Uri(AppSettings.ElasticsearchHost)
             ).DefaultIndex($"{AppSettings.ElasticsearchPrefix}index_meta")
+            .ThrowExceptions(true)
         );
-
 
         /// <summary>
         /// The actual name of the index.
@@ -49,6 +49,7 @@ namespace osu.ElasticIndexer
                 .Settings(s => s.NumberOfShards(1))
                 .Mappings(ms => ms.Map<IndexMeta>(m => m.AutoMap()))
                 .WaitForActiveShards("1")
+                .RequestConfiguration(r => r.ThrowExceptions(false))
             );
         }
 

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -40,8 +40,8 @@ namespace osu.ElasticIndexer
         [Date(Name = "updated_at")]
         public DateTimeOffset UpdatedAt { get; set; }
 
-        [Text(Name = "version")]
-        public string Version { get; set; }
+        [Text(Name = "schema")]
+        public string Schema { get; set; }
 
         public static ICreateIndexResponse CreateIndex()
         {
@@ -54,7 +54,7 @@ namespace osu.ElasticIndexer
 
         public static void MarkAsReady(string index)
         {
-            client.Update<IndexMeta, object>(index, d => d.Doc(new { Version = AppSettings.Version }));
+            client.Update<IndexMeta, object>(index, d => d.Doc(new { Schema = AppSettings.Schema }));
         }
 
         public static void Refresh()
@@ -91,7 +91,7 @@ namespace osu.ElasticIndexer
             var response = client.Search<IndexMeta>(s => s
                 .Query(q => q
                     .Term(t => t.Alias, name) && q
-                    .Term(t => t.Version, AppSettings.Version)
+                    .Term(t => t.Schema, AppSettings.Schema)
                 )
                 .Sort(sort => sort.Descending(p => p.UpdatedAt))
             );

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -88,7 +88,15 @@ namespace osu.ElasticIndexer
 
         public static IndexMeta GetByAliasForCurrentVersion(string name)
         {
-            return GetByAlias(name).Where(x => x.Version == AppSettings.Version).FirstOrDefault();
+            var response = client.Search<IndexMeta>(s => s
+                .Query(q => q
+                    .Term(t => t.Alias, name) && q
+                    .Term(t => t.Version, AppSettings.Version)
+                )
+                .Sort(sort => sort.Descending(p => p.UpdatedAt))
+            );
+
+            return response.Documents.FirstOrDefault();
         }
     }
 }

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -1,4 +1,3 @@
-using System.Net;
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
@@ -51,6 +50,11 @@ namespace osu.ElasticIndexer
                 .Mappings(ms => ms.Map<IndexMeta>(m => m.AutoMap()))
                 .WaitForActiveShards("1")
             );
+        }
+
+        public static void MarkAsReady(string index)
+        {
+            client.Update<IndexMeta, object>(index, d => d.Doc(new { Ready = true }));
         }
 
         public static void Refresh()

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -32,7 +32,7 @@ namespace osu.ElasticIndexer
         public string Alias { get; set; }
 
         [Number(NumberType.Long, Name = "last_id")]
-        public long LastId { get; set; }
+        public ulong LastId { get; set; }
 
         [Date(Name = "updated_at")]
         public DateTimeOffset UpdatedAt { get; set; }

--- a/osu.ElasticIndexer/IndexMeta.cs
+++ b/osu.ElasticIndexer/IndexMeta.cs
@@ -54,7 +54,7 @@ namespace osu.ElasticIndexer
 
         public static void MarkAsReady(string index)
         {
-            client.Update<IndexMeta, object>(index, d => d.Doc(new { Schema = AppSettings.Schema }));
+            client.Update<IndexMeta, object>(index, d => d.Doc(new { AppSettings.Schema }));
         }
 
         public static void Refresh()

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -31,7 +31,7 @@ namespace osu.ElasticIndexer
 
                 dbConnection.Open();
 
-                var max = dbConnection.QuerySingle<ulong?>($"SELECT MAX({cursorColumn}) FROM {table} WHERE {where}");
+                var max = dbConnection.QuerySingle<long?>($"SELECT MAX({cursorColumn}) FROM {table} WHERE {where}");
                 if (!max.HasValue) yield break;
 
                 string query = $"select * from {table} where {cursorColumn} > @lastId and {cursorColumn} <= @max {additionalWheres} order by {cursorColumn} asc limit @chunkSize;";

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -14,13 +14,13 @@ namespace osu.ElasticIndexer
     [CursorColumn("id")]
     public abstract class Model
     {
-        public abstract long CursorValue { get; }
+        public abstract ulong CursorValue { get; }
 
-        public static IEnumerable<List<T>> Chunk<T>(string where, int chunkSize = 10000, long? resumeFrom = null) where T : Model
+        public static IEnumerable<List<T>> Chunk<T>(string where, int chunkSize = 10000, ulong? resumeFrom = null) where T : Model
         {
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
-                long? lastId = resumeFrom ?? 0;
+                ulong? lastId = resumeFrom ?? 0;
                 var cursorColumn = typeof(T).GetCustomAttributes<CursorColumnAttribute>().First().Name;
                 var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
 
@@ -51,7 +51,7 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static IEnumerable<List<T>> Chunk<T>(int chunkSize = 10000, long? resumeFrom = null) where T : Model =>
+        public static IEnumerable<List<T>> Chunk<T>(int chunkSize = 10000, ulong? resumeFrom = null) where T : Model =>
             Chunk<T>(null, chunkSize, resumeFrom);
     }
 }

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -32,7 +32,7 @@ namespace osu.ElasticIndexer
                 if (!string.IsNullOrWhiteSpace(where))
                     maxQuery += $" WHERE {where}";
 
-                var max = dbConnection.QuerySingle<ulong?>(maxQuery);
+                var max = dbConnection.QuerySingleOrDefault<ulong?>(maxQuery);
                 if (!max.HasValue) yield break;
 
                 // FIXME: this is terrible.

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -21,8 +21,8 @@ namespace osu.ElasticIndexer
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
                 ulong? lastId = resumeFrom ?? 0;
-                var cursorColumn = typeof(T).GetCustomAttributes<CursorColumnAttribute>().First().Name;
-                var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
+                var cursorColumn = Model.GetCursorColumnName<T>();
+                var table = Model.GetTableName<T>();
 
                 Console.WriteLine($"Starting {table} from {lastId}...");
 
@@ -53,5 +53,15 @@ namespace osu.ElasticIndexer
 
         public static IEnumerable<List<T>> Chunk<T>(int chunkSize = 10000, ulong? resumeFrom = null) where T : Model =>
             Chunk<T>(null, chunkSize, resumeFrom);
+
+        public static string GetCursorColumnName<T>() where T : Model
+        {
+            return typeof(T).GetCustomAttributes<CursorColumnAttribute>().First().Name;
+        }
+
+        public static string GetTableName<T>() where T : Model
+        {
+            return typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
+        }
     }
 }

--- a/osu.ElasticIndexer/Model.cs
+++ b/osu.ElasticIndexer/Model.cs
@@ -21,8 +21,8 @@ namespace osu.ElasticIndexer
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
                 ulong? lastId = resumeFrom ?? 0;
-                var cursorColumn = Model.GetCursorColumnName<T>();
-                var table = Model.GetTableName<T>();
+                var cursorColumn = GetCursorColumnName<T>();
+                var table = GetTableName<T>();
 
                 Console.WriteLine($"Starting {table} from {lastId}...");
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -39,7 +39,7 @@ namespace osu.ElasticIndexer
             DefaultTypeMap.MatchNamesWithUnderscores = true;
             IndexMeta.CreateIndex();
 
-            Console.WriteLine($"rebuilding index: `{AppSettings.IsRebuild}`");
+            Console.WriteLine($"Rebuilding index: `{AppSettings.IsRebuild}`");
             if (AppSettings.IsWatching)
                 runWatchLoop();
             else

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using System.Threading;
-using System.Linq;
 using Dapper;
 using MySql.Data.MySqlClient;
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -42,9 +42,7 @@ namespace osu.ElasticIndexer
             if (AppSettings.IsWatching)
                 runWatchLoop();
             else
-            {
-                runIndexing(AppSettings.ResumeFrom);
-            }
+                runIndexing();
 
             if (AppSettings.UseDocker)
             {
@@ -67,7 +65,7 @@ namespace osu.ElasticIndexer
             while (true)
             {
                 // run continuously with automatic resume logic
-                runIndexing(null);
+                runIndexing();
                 Thread.Sleep(AppSettings.PollingInterval);
             }
         }
@@ -75,8 +73,7 @@ namespace osu.ElasticIndexer
         /// <summary>
         /// Performs a single indexing run for all specified modes.
         /// </summary>
-        /// <param name="resumeFrom">An optional resume point.</param>
-        private static void runIndexing(ulong? resumeFrom)
+        private static void runIndexing()
         {
             var suffix = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
 
@@ -84,7 +81,7 @@ namespace osu.ElasticIndexer
             {
                 var indexer = getIndexerFromModeString(mode);
                 indexer.Suffix = suffix;
-                indexer.ResumeFrom = resumeFrom;
+                indexer.ResumeFrom = AppSettings.ResumeFrom;
                 indexer.Run();
             }
         }

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Globalization;
 using System.Threading;
 using Dapper;
 using MySql.Data.MySqlClient;
@@ -90,7 +89,7 @@ namespace osu.ElasticIndexer
         private static IIndexer getIndexerFromModeString(string mode)
         {
             var indexName = $"{AppSettings.Prefix}high_scores_{mode}";
-            var scoreType = getTypeFromModeString(mode);
+            var scoreType = HighScore.GetTypeFromModeString(mode);
 
             Type indexerType = typeof(HighScoreIndexer<>).MakeGenericType(scoreType);
 
@@ -104,13 +103,6 @@ namespace osu.ElasticIndexer
             };
 
             return indexer;
-        }
-
-        private static Type getTypeFromModeString(string mode)
-        {
-            var className = $"{typeof(HighScore).Namespace}.HighScore{CultureInfo.InvariantCulture.TextInfo.ToTitleCase(mode)}";
-
-            return Type.GetType(className, true);
         }
     }
 }

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -66,6 +66,7 @@ namespace osu.ElasticIndexer
             {
                 // run continuously with automatic resume logic
                 runIndexing();
+                AppSettings.IsNew = false;
                 Thread.Sleep(AppSettings.PollingInterval);
             }
         }

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -79,10 +79,17 @@ namespace osu.ElasticIndexer
 
             foreach (var mode in AppSettings.Modes)
             {
-                var indexer = getIndexerFromModeString(mode);
-                indexer.Suffix = suffix;
-                indexer.ResumeFrom = AppSettings.ResumeFrom;
-                indexer.Run();
+                try
+                {
+                    var indexer = getIndexerFromModeString(mode);
+                    indexer.Suffix = suffix;
+                    indexer.ResumeFrom = AppSettings.ResumeFrom;
+                    indexer.Run();
+                }
+                catch (VersionMismatchException ex)
+                {
+                    Console.WriteLine(ex.Message);
+                }
             }
         }
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -79,7 +79,7 @@ namespace osu.ElasticIndexer
         /// Performs a single indexing run for all specified modes.
         /// </summary>
         /// <param name="resumeFrom">An optional resume point.</param>
-        private static void runIndexing(long? resumeFrom)
+        private static void runIndexing(ulong? resumeFrom)
         {
             var suffix = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -99,7 +99,7 @@ namespace osu.ElasticIndexer
             // A switchover probably happened and this process has nothing to do, so just exit.
             if (AppSettings.Modes.ToHashSet().SetEquals(mismatched))
             {
-                Console.Error.WriteLine("All versions mismatched, exiting.");
+                Console.Error.WriteLine("All schema versions mismatched, exiting.");
                 Environment.Exit(0);
             }
         }

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -39,7 +39,7 @@ namespace osu.ElasticIndexer
             DefaultTypeMap.MatchNamesWithUnderscores = true;
             IndexMeta.CreateIndex();
 
-            Console.WriteLine($"Using queue: `{AppSettings.IsUsingQueue}`");
+            Console.WriteLine($"rebuilding index: `{AppSettings.IsRebuild}`");
             if (AppSettings.IsWatching)
                 runWatchLoop();
             else

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -80,14 +80,9 @@ namespace osu.ElasticIndexer
 
             foreach (var mode in AppSettings.Modes)
             {
-                var type = getTypeFromModeString(mode);
-                var modeInt = ((RulesetIdAttribute) type.GetCustomAttributes(typeof(RulesetIdAttribute), true).First()).Id;
-                var firstPendingQueueId = AppSettings.IsRebuild ? ScoreProcessQueue.GetFirstPendingQueueId(modeInt) : null;
-
                 var indexer = getIndexerFromModeString(mode);
                 indexer.Suffix = suffix;
                 indexer.ResumeFrom = AppSettings.ResumeFrom;
-                indexer.FirstPendingQueueId = firstPendingQueueId;
                 indexer.Run();
             }
         }

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -87,10 +87,8 @@ namespace osu.ElasticIndexer
                 var indexer = getIndexerFromModeString(mode);
                 indexer.Suffix = suffix;
                 indexer.ResumeFrom = AppSettings.ResumeFrom;
+                indexer.FirstPendingQueueId = firstPendingQueueId;
                 indexer.Run();
-
-                if (firstPendingQueueId.HasValue)
-                    ScoreProcessQueue.UnCompleteQueued(modeInt, firstPendingQueueId.Value);
             }
         }
 

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -100,6 +100,7 @@ namespace osu.ElasticIndexer
             {
                 Console.WriteLine($"{args.Count} records took {args.TimeTaken}");
                 if (args.Count > 0) Console.WriteLine($"{args.Count / args.TimeTaken.TotalSeconds} records/s");
+                Console.WriteLine();
             };
 
             return indexer;

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -64,9 +64,6 @@ namespace osu.ElasticIndexer
         {
             Console.WriteLine($"Running in watch mode with {AppSettings.PollingInterval}ms poll.");
 
-            // run once with config resuming
-            runIndexing(AppSettings.ResumeFrom);
-
             while (true)
             {
                 // run continuously with automatic resume logic

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -100,7 +100,7 @@ namespace osu.ElasticIndexer
             if (AppSettings.Modes.ToHashSet().SetEquals(mismatched))
             {
                 Console.Error.WriteLine("All versions mismatched, exiting.");
-                System.Environment.Exit(0);
+                Environment.Exit(0);
             }
         }
 

--- a/osu.ElasticIndexer/RulesetIdAttribute.cs
+++ b/osu.ElasticIndexer/RulesetIdAttribute.cs
@@ -14,7 +14,5 @@ namespace osu.ElasticIndexer
         public int Id { get; }
 
         public RulesetIdAttribute(int id) => Id = id;
-
-
-    }
+   }
 }

--- a/osu.ElasticIndexer/RulesetIdAttribute.cs
+++ b/osu.ElasticIndexer/RulesetIdAttribute.cs
@@ -14,5 +14,7 @@ namespace osu.ElasticIndexer
         public int Id { get; }
 
         public RulesetIdAttribute(int id) => Id = id;
+
+
     }
 }

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -21,7 +21,7 @@ namespace osu.ElasticIndexer
 
         public ulong ScoreId { get; set; }
 
-        public static void CompleteQueued<T>(List<ScoreProcessQueue> queueItems) where T : HighScore
+        public static void CompleteQueued(List<ScoreProcessQueue> queueItems)
         {
             if (!queueItems.Any()) return;
             var queueIds = queueItems.Select(x => x.QueueId);

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -52,5 +52,27 @@ namespace osu.ElasticIndexer
                 return dbConnection.Query<T>(query, parameters).AsList();
             }
         }
+
+        public static ulong? GetFirstPendingQueueId(int mode)
+        {
+            using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
+            {
+                dbConnection.Open();
+
+                const string query = "select MIN(queue_id) from score_process_queue where mode = @mode";
+                return dbConnection.QuerySingleOrDefault<ulong>(query, new { mode });
+            }
+        }
+
+        public static void UnCompleteQueued(int mode, ulong from)
+        {
+            using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
+            {
+                dbConnection.Open();
+
+                const string query = "update score_process_queue set status = 1 where queue_id >= @from and mode = @mode";
+                dbConnection.Execute(query, new { from, mode });
+            }
+        }
     }
 }

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -58,7 +58,7 @@ namespace osu.ElasticIndexer
                 dbConnection.Open();
 
                 const string query = "SELECT queue_id FROM score_process_queue WHERE status = 2 AND mode = @mode order by queue_id DESC LIMIT 1";
-                return dbConnection.QuerySingle<ulong?>(query, new { mode });
+                return dbConnection.QuerySingleOrDefault<ulong?>(query, new { mode });
             }
         }
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -31,7 +31,7 @@ namespace osu.ElasticIndexer
                 dbConnection.Open();
 
                 const string query = "update score_process_queue set status = 2 where queue_id in @queueIds";
-                dbConnection.Execute(query, new { queueItems });
+                dbConnection.Execute(query, new { queueIds });
             }
         }
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -20,9 +20,9 @@ namespace osu.ElasticIndexer
         // These are the only columns we care about at the momemnt.
         public uint QueueId { get; set; }
 
-        public ulong ScoreId { get; set; }
+        public long ScoreId { get; set; }
 
-        public static void CompleteQueued<T>(List<ulong> scoreIds) where T : HighScore
+        public static void CompleteQueued<T>(List<long> scoreIds) where T : HighScore
         {
             if (!scoreIds.Any()) return;
 
@@ -37,7 +37,7 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static List<T> FetchByScoreIds<T>(List<ulong> scoreIds) where T : HighScore
+        public static List<T> FetchByScoreIds<T>(List<long> scoreIds) where T : HighScore
         {
             var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -60,7 +60,7 @@ namespace osu.ElasticIndexer
                 dbConnection.Open();
 
                 const string query = "SELECT MAX(queue_id) FROM score_process_queue WHERE status = 2 AND mode = @mode";
-                return dbConnection.QuerySingleOrDefault<ulong>(query, new { mode });
+                return dbConnection.QuerySingle<ulong?>(query, new { mode });
             }
         }
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -58,7 +58,7 @@ namespace osu.ElasticIndexer
             {
                 dbConnection.Open();
 
-                const string query = "SELECT MAX(queue_id) FROM score_process_queue WHERE status = 2 AND mode = @mode";
+                const string query = "SELECT queue_id FROM score_process_queue WHERE status = 2 AND mode = @mode order by queue_id DESC LIMIT 1";
                 return dbConnection.QuerySingle<ulong?>(query, new { mode });
             }
         }

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -20,9 +20,9 @@ namespace osu.ElasticIndexer
         // These are the only columns we care about at the momemnt.
         public uint QueueId { get; set; }
 
-        public long ScoreId { get; set; }
+        public ulong ScoreId { get; set; }
 
-        public static void CompleteQueued<T>(List<long> scoreIds) where T : HighScore
+        public static void CompleteQueued<T>(List<ulong> scoreIds) where T : HighScore
         {
             if (!scoreIds.Any()) return;
 
@@ -37,7 +37,7 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static List<T> FetchByScoreIds<T>(List<long> scoreIds) where T : HighScore
+        public static List<T> FetchByScoreIds<T>(List<ulong> scoreIds) where T : HighScore
         {
             var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -21,18 +21,17 @@ namespace osu.ElasticIndexer
 
         public ulong ScoreId { get; set; }
 
-        public static void CompleteQueued<T>(List<ulong> scoreIds) where T : HighScore
+        public static void CompleteQueued<T>(List<ScoreProcessQueue> queueItems) where T : HighScore
         {
-            if (!scoreIds.Any()) return;
+            if (!queueItems.Any()) return;
+            var queueIds = queueItems.Select(x => x.QueueId);
 
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
-                var mode = HighScore.GetRulesetId<T>();
-
                 dbConnection.Open();
 
-                const string query = "update score_process_queue set status = 2 where score_id in @scoreIds and mode = @mode";
-                dbConnection.Execute(query, new { scoreIds, mode });
+                const string query = "update score_process_queue set status = 2 where queue_id in @queueIds";
+                dbConnection.Execute(query, new { queueItems });
             }
         }
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -15,7 +15,7 @@ namespace osu.ElasticIndexer
     [Table("score_process_queue")]
     public class ScoreProcessQueue : Model
     {
-        public override long CursorValue => QueueId;
+        public override ulong CursorValue => QueueId;
 
         // These are the only columns we care about at the momemnt.
         public uint QueueId { get; set; }

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -38,7 +38,7 @@ namespace osu.ElasticIndexer
 
         public static List<T> FetchByScoreIds<T>(List<ulong> scoreIds) where T : HighScore
         {
-            var table = Model.GetTableName<T>();
+            var table = GetTableName<T>();
 
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -64,10 +64,12 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static void UnCompleteQueued(int mode, ulong from)
+        public static void UnCompleteQueued<T>(ulong from) where T : HighScore
         {
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
+                var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+
                 dbConnection.Open();
 
                 const string query = "update score_process_queue set status = 1 where queue_id >= @from and mode = @mode";

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Dapper;
 using Dapper.Contrib.Extensions;
 using MySql.Data.MySqlClient;
@@ -28,7 +27,7 @@ namespace osu.ElasticIndexer
 
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
-                var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+                var mode = HighScore.GetRulesetId<T>();
 
                 dbConnection.Open();
 
@@ -39,7 +38,7 @@ namespace osu.ElasticIndexer
 
         public static List<T> FetchByScoreIds<T>(List<ulong> scoreIds) where T : HighScore
         {
-            var table = typeof(T).GetCustomAttributes<TableAttribute>().First().Name;
+            var table = Model.GetTableName<T>();
 
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
@@ -68,7 +67,7 @@ namespace osu.ElasticIndexer
         {
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
-                var mode = typeof(T).GetCustomAttributes<RulesetIdAttribute>().First().Id;
+                var mode = HighScore.GetRulesetId<T>();
 
                 dbConnection.Open();
 

--- a/osu.ElasticIndexer/ScoreProcessQueue.cs
+++ b/osu.ElasticIndexer/ScoreProcessQueue.cs
@@ -53,13 +53,13 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public static ulong? GetFirstPendingQueueId(int mode)
+        public static ulong? GetLastProcessedQueueId(int mode)
         {
             using (var dbConnection = new MySqlConnection(AppSettings.ConnectionString))
             {
                 dbConnection.Open();
 
-                const string query = "select MIN(queue_id) from score_process_queue where mode = @mode";
+                const string query = "SELECT MAX(queue_id) FROM score_process_queue WHERE status = 2 AND mode = @mode";
                 return dbConnection.QuerySingleOrDefault<ulong>(query, new { mode });
             }
         }
@@ -72,7 +72,7 @@ namespace osu.ElasticIndexer
 
                 dbConnection.Open();
 
-                const string query = "update score_process_queue set status = 1 where queue_id >= @from and mode = @mode";
+                const string query = "UPDATE score_process_queue SET status = 1 WHERE queue_id > @from AND mode = @mode";
                 dbConnection.Execute(query, new { from, mode });
             }
         }

--- a/osu.ElasticIndexer/VersionMismatchException.cs
+++ b/osu.ElasticIndexer/VersionMismatchException.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.ElasticIndexer
+{
+    public class VersionMismatchException : Exception
+    {
+        public VersionMismatchException(string message) : base(message) {}
+    }
+}

--- a/osu.ElasticIndexer/osu.ElasticIndexer.csproj
+++ b/osu.ElasticIndexer/osu.ElasticIndexer.csproj
@@ -4,13 +4,13 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="dapper" Version="1.50.5" />
-    <PackageReference Include="Dapper.Contrib" Version="1.50.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.2" />
-    <PackageReference Include="MySql.Data" Version="8.0.11" />
-    <PackageReference Include="NEST" Version="6.1.0" />
+    <PackageReference Include="dapper" Version="1.60.6" />
+    <PackageReference Include="Dapper.Contrib" Version="1.60.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="MySql.Data" Version="8.0.17" />
+    <PackageReference Include="NEST" Version="6.8.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/osu.ElasticIndexer/schemas/high_scores.json
+++ b/osu.ElasticIndexer/schemas/high_scores.json
@@ -1,6 +1,6 @@
 {
   "mappings": {
-    "high_score": {
+    "_doc": {
       "dynamic": false,
       "properties": {
         "score_id": {

--- a/osu.ElasticIndexer/schemas/high_scores.json
+++ b/osu.ElasticIndexer/schemas/high_scores.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "_doc": {
+      "_source": {
+        "enabled": false
+      },
       "dynamic": false,
       "properties": {
         "score_id": {


### PR DESCRIPTION
requires #7 

requires osu-web to be updated not to use `_source` when retrieving high scores https://github.com/ppy/osu-web/pull/4772

Removing `_source` drops the index size by about half and aren't really necessary for aggregations where none of the data in the `_source` field is used.