### PR TITLE
Throw exception on elasticsearch connection error

### DIFF
--- a/osu.ElasticIndexer/Client.cs
+++ b/osu.ElasticIndexer/Client.cs
@@ -14,9 +14,10 @@ namespace osu.ElasticIndexer
     public class Client
     {
         // shared client without a default index.
-        public readonly ElasticClient ElasticClient = new ElasticClient
-            (new ConnectionSettings(new Uri(AppSettings.ElasticsearchHost)).ThrowExceptions()
+        public readonly ElasticClient ElasticClient = new ElasticClient(
+            new ConnectionSettings(new Uri(AppSettings.ElasticsearchHost)).ThrowExceptions()
         );
+
         public readonly string AliasName = $"{AppSettings.Prefix}solo_scores";
 
         /// <summary>

--- a/osu.ElasticIndexer/Client.cs
+++ b/osu.ElasticIndexer/Client.cs
@@ -14,7 +14,9 @@ namespace osu.ElasticIndexer
     public class Client
     {
         // shared client without a default index.
-        public readonly ElasticClient ElasticClient = new ElasticClient(new ConnectionSettings(new Uri(AppSettings.ElasticsearchHost)));
+        public readonly ElasticClient ElasticClient = new ElasticClient
+            (new ConnectionSettings(new Uri(AppSettings.ElasticsearchHost)).ThrowExceptions()
+        );
         public readonly string AliasName = $"{AppSettings.Prefix}solo_scores";
 
         /// <summary>

--- a/osu.ElasticIndexer/Commands/ListIndicesCommand.cs
+++ b/osu.ElasticIndexer/Commands/ListIndicesCommand.cs
@@ -15,6 +15,7 @@ namespace osu.ElasticIndexer.Commands
         public int OnExecute()
         {
             var indices = client.GetIndices(client.AliasName, ExpandWildcards.All);
+
             if (indices.Count > 0)
             {
                 var response = client.ElasticClient.Cat.Indices(descriptor => descriptor.Index(indices.Keys.Select(k => k.Name).ToArray()));

--- a/osu.ElasticIndexer/Commands/ListIndicesCommand.cs
+++ b/osu.ElasticIndexer/Commands/ListIndicesCommand.cs
@@ -15,15 +15,18 @@ namespace osu.ElasticIndexer.Commands
         public int OnExecute()
         {
             var indices = client.GetIndices(client.AliasName, ExpandWildcards.All);
-            var response = client.ElasticClient.Cat.Indices(descriptor => descriptor.Index(indices.Keys.Select(k => k.Name).ToArray()));
-
-            foreach (var record in response.Records)
+            if (indices.Count > 0)
             {
-                var indexState = indices[record.Index];
-                var schema = indexState.Mappings.Meta?["schema"];
-                var aliased = indexState.Aliases.ContainsKey(client.AliasName);
+                var response = client.ElasticClient.Cat.Indices(descriptor => descriptor.Index(indices.Keys.Select(k => k.Name).ToArray()));
 
-                Console.WriteLine($"{record.Index} schema:{schema} aliased:{aliased} {record.Status} {record.DocsCount} {record.PrimaryStoreSize}");
+                foreach (var record in response.Records)
+                {
+                    var indexState = indices[record.Index];
+                    var schema = indexState.Mappings.Meta?["schema"];
+                    var aliased = indexState.Aliases.ContainsKey(client.AliasName);
+
+                    Console.WriteLine($"{record.Index} schema:{schema} aliased:{aliased} {record.Status} {record.DocsCount} {record.PrimaryStoreSize}");
+                }
             }
 
             return 0;

--- a/osu.ElasticIndexer/IndexQueueProcessor.cs
+++ b/osu.ElasticIndexer/IndexQueueProcessor.cs
@@ -83,6 +83,7 @@ namespace osu.ElasticIndexer
                 // If it gets to here, then something is really wrong, just bail out.
                 Console.WriteLine(ConsoleColor.Red, response.ToString());
                 Console.WriteLine(ConsoleColor.Red, response.OriginalException?.Message);
+
                 foreach (var item in items)
                 {
                     item.Failed = true;
@@ -128,7 +129,7 @@ namespace osu.ElasticIndexer
             // Spin until valid response from elasticsearch.
             while (!client.ElasticClient.Indices.Get(index, d => d.RequestConfiguration(r => r.ThrowExceptions(false))).IsValid)
             {
-                Console.WriteLine(ConsoleColor.Yellow, $"wating 10 seconds for server to come alive...");
+                Console.WriteLine(ConsoleColor.Yellow, "wating 10 seconds for server to come alive...");
                 Task.Delay(TimeSpan.FromSeconds(10)).Wait();
             }
         }

--- a/osu.ElasticIndexer/IndexQueueProcessor.cs
+++ b/osu.ElasticIndexer/IndexQueueProcessor.cs
@@ -54,11 +54,16 @@ namespace osu.ElasticIndexer
                                  .IndexMany(add)
                                  .DeleteMany(remove);
 
+            var response = client.ElasticClient.Bulk(bulkDescriptor);
+
+            handleResponse(response, items);
+        }
+
+        private BulkResponse dispatch(BulkDescriptor bulkDescriptor)
+        {
             try
             {
-                var response = client.ElasticClient.Bulk(bulkDescriptor);
-
-                handleResponse(response, items);
+                return client.ElasticClient.Bulk(bulkDescriptor);
             }
             catch (ElasticsearchClientException ex)
             {
@@ -66,6 +71,8 @@ namespace osu.ElasticIndexer
                 Console.WriteLine(ConsoleColor.Red, ex.Message);
                 Console.WriteLine(ConsoleColor.Yellow, ex.InnerException?.Message);
                 waitUntilActive();
+
+                return dispatch(bulkDescriptor);
             }
         }
 


### PR DESCRIPTION
Will throw an exception when failing to get a success or known error response (2xx or 4xx) from elasticsearch.

Other than the indexing handler it probably makes more sense to just exit with an exception instead of checking every response.
This will also avoid crashing if elasticsearch gets restarted or something during indexing