### PR TITLE
Require schema when using pump all command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ For testing purposes, we can add fake items to the queue:
 
 It should be noted that these items will not exist or match the ones in the database.
 
+## Adding existing database records to the queue
+
+    schema=1 dotnet run all
+
+will read existing `solo_scores` in chunks and add them to the queue for indexing. Only scores with a corresponding `solo_scores_performance` and `phpbb_users` entries will be queued.
+
+Extra options:
+
+`--from {id}`: `solo_scores.id` to start reading from
+
+`--switch`: Sets the schema version after the last item is queued; it does not wait for the item to be indexed; this option is provided as a conveninence for testing.
+
 # (Re)Populating an index
 
 Populating an index is done by pushing score items to a queue.

--- a/osu.ElasticIndexer/Commands/PumpAllScoresCommand.cs
+++ b/osu.ElasticIndexer/Commands/PumpAllScoresCommand.cs
@@ -25,6 +25,9 @@ namespace osu.ElasticIndexer.Commands
 
         public int OnExecute(CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(AppSettings.Schema))
+                throw new MissingSchemaException();
+
             var redis = new Redis();
             var currentSchema = redis.GetSchemaVersion();
             Console.WriteLine(ConsoleColor.Cyan, $"Current schema version is: {currentSchema}");


### PR DESCRIPTION
- using `all` should require `schema` env to be set (makes no sense to push to queue, otherwise)
- add missing documentation