### PR TITLE
Order index by total_score

### DIFF
--- a/osu.ElasticIndexer/SoloScore.cs
+++ b/osu.ElasticIndexer/SoloScore.cs
@@ -33,16 +33,16 @@ namespace osu.ElasticIndexer
 
         // Properties ordered in the order they appear in the table.
 
-        [Number(NumberType.Long)]
+        [Keyword]
         public long id { get; set; }
 
-        [Number(NumberType.Long)]
+        [Keyword]
         public uint beatmap_id { get; set; }
 
-        [Number(NumberType.Long)]
+        [Keyword]
         public uint user_id { get; set; }
 
-        [Number(NumberType.Short)]
+        [Keyword]
         public int ruleset_id { get; set; }
 
         [Date(Format = "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss")]
@@ -66,7 +66,7 @@ namespace osu.ElasticIndexer
         }
 
         [Computed]
-        [Number(NumberType.Integer)]
+        [Keyword]
         public int? build_id => scoreData.build_id;
 
         [Computed]

--- a/osu.ElasticIndexer/SoloScore.cs
+++ b/osu.ElasticIndexer/SoloScore.cs
@@ -33,7 +33,7 @@ namespace osu.ElasticIndexer
 
         // Properties ordered in the order they appear in the table.
 
-        [Keyword]
+        [Number(NumberType.Long)]
         public long id { get; set; }
 
         [Keyword]

--- a/osu.ElasticIndexer/schemas/solo_scores.json
+++ b/osu.ElasticIndexer/schemas/solo_scores.json
@@ -9,10 +9,10 @@
         "type": "float"
       },
       "beatmap_id": {
-        "type": "long"
+        "type": "keyword"
       },
       "build_id": {
-        "type": "integer"
+        "type": "keyword"
       },
       "country_code": {
         "type": "keyword"
@@ -26,7 +26,7 @@
         "type": "date"
       },
       "id": {
-        "type": "long"
+        "type": "keyword"
       },
       "max_combo": {
         "type": "integer"
@@ -44,7 +44,7 @@
         "type": "keyword"
       },
       "ruleset_id": {
-        "type": "short"
+        "type": "keyword"
       },
       "started_at": {
         "format": "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss",
@@ -58,7 +58,7 @@
         "type": "date"
       },
       "user_id": {
-        "type": "long"
+        "type": "keyword"
       }
     }
   },

--- a/osu.ElasticIndexer/schemas/solo_scores.json
+++ b/osu.ElasticIndexer/schemas/solo_scores.json
@@ -26,7 +26,7 @@
         "type": "date"
       },
       "id": {
-        "type": "keyword"
+        "type": "long"
       },
       "max_combo": {
         "type": "integer"

--- a/osu.ElasticIndexer/schemas/solo_scores.json
+++ b/osu.ElasticIndexer/schemas/solo_scores.json
@@ -65,7 +65,11 @@
   "settings": {
     "index": {
       "number_of_shards": "1",
-      "number_of_replicas": "0"
+      "number_of_replicas": "0",
+      "sort": {
+        "field": "total_score",
+        "order": "desc"
+      }
     }
   }
 }


### PR DESCRIPTION
Orders the index by `total_score` which according to Elastic, can improve the performance of querying aggregations with a sort order since lucene can assume when it no longer has to load extra segments.

This needs actual testing with a reasonably sized dataset to actually compare with the unordered index.

Also changes some of the fields to `keyword` as those are supposedly better for term filtering when ranges are not used.