### PR TITLE
Select country_acronym as country_code

### DIFF
--- a/osu.ElasticIndexer/SoloScore.cs
+++ b/osu.ElasticIndexer/SoloScore.cs
@@ -15,7 +15,7 @@ namespace osu.ElasticIndexer
     [SuppressMessage("Style", "IDE1006")]
     [ElasticsearchType(IdProperty = nameof(id))]
     [ChunkOn(
-        Query = @"s.*, pp, country_acronym, user_warnings FROM solo_scores s
+        Query = @"s.*, pp, country_acronym AS country_code, user_warnings FROM solo_scores s
         LEFT JOIN solo_scores_performance ON score_id = s.id
         JOIN phpbb_users USING (user_id)",
         CursorColumn = "s.id",


### PR DESCRIPTION
Forgot we're using `country_code` as the field name not `country_acronym` in #105, to match the naming of other code.