### PR TITLE
Elasticsearch 8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,33 @@ Component for loading [osu!](https://osu.ppy.sh) scores into Elasticsearch.
 
 - .NET 6
 - Elasticsearch 7
-- Redis
+- Redis 6
+
+## Elasticsearch 8 compatiblity
+
+Requires minimum Elasticsearch 8.2.
+
+The following env needs to be set on the indexer:
+
+```bash
+ELASTIC_CLIENT_APIVERSIONING=true
+```
+
+and the following must be set in elasticsearch server configuration
+`elasticsearch.yml`
+
+```yml
+xpack.security.enabled: false
+```
+
+or docker environment, e.g. in docker compose:
+```yml
+environment:
+  xpack.security.enabled: false
+```
+
+This will enable http connections to elasticsearch and disable the https and authentication requirement, as well as, returning a compatible response to the client.
+
 
 # Usage
 

--- a/osu.ElasticIndexer/IndexQueueProcessor.cs
+++ b/osu.ElasticIndexer/IndexQueueProcessor.cs
@@ -90,6 +90,7 @@ namespace osu.ElasticIndexer
                 }
 
                 stop();
+                return;
             }
 
             // Elasticsearch bulk thread pool is full.


### PR DESCRIPTION
Seems to work with 8.2+ (earlier versions have a bug returning an incompatible response) while using the `7.17+` .NET client (8 client is still beta).

`xpack.security.enabled: false` needs to be set in elasticsearch.
`ELASTIC_CLIENT_APIVERSIONING=true` needs to be set on the indexer to enable compatibility.