### PR TITLE
Add a post-schema switch pass to database reader command

### DIFF
--- a/osu.ElasticIndexer/Commands/IndexCommand.cs
+++ b/osu.ElasticIndexer/Commands/IndexCommand.cs
@@ -24,7 +24,7 @@ namespace osu.ElasticIndexer.Commands
             var scoreItem = new ScoreItem { ScoreId = id };
             Processor.PushToQueue(scoreItem);
 
-            Console.WriteLine(ConsoleColor.Cyan, $"Queued to {Processor.QueueName}: {scoreItem}");
+            Console.WriteLine(ConsoleColor.Green, $"Queued to {Processor.QueueName}: {scoreItem}");
 
             return 0;
         }

--- a/osu.ElasticIndexer/Commands/PumpAllScoresCommand.cs
+++ b/osu.ElasticIndexer/Commands/PumpAllScoresCommand.cs
@@ -34,8 +34,8 @@ namespace osu.ElasticIndexer.Commands
 
             var redis = new Redis();
             var currentSchema = redis.GetSchemaVersion();
-            Console.WriteLine(ConsoleColor.Cyan, $"Current schema version is: {currentSchema}");
-            Console.WriteLine(ConsoleColor.Cyan, $"Pushing to queue with schema: {AppSettings.Schema}");
+            Console.WriteLine(ConsoleColor.Green, $"Current schema version is: {currentSchema}");
+            Console.WriteLine(ConsoleColor.Green, $"Pushing to queue with schema: {AppSettings.Schema}");
 
             if (Switch && currentSchema == AppSettings.Schema)
                 Console.WriteLine(ConsoleColor.Yellow, "Queue watchers will not update the alias if schema does not change!");

--- a/osu.ElasticIndexer/Console.cs
+++ b/osu.ElasticIndexer/Console.cs
@@ -10,6 +10,17 @@ namespace osu.ElasticIndexer
         public static void WriteLine(string? value = null) =>
             System.Console.WriteLine(value);
 
+        /// <summary>
+        /// General guidelines for the colours used:
+        /// Cyan - Typically informational.
+        /// Green - Confirmations, notable operating messages.
+        /// Red - Critical failure, destructive operation.
+        /// Yellow - Warnings, important messages, etc.
+        ///
+        /// Consecutive messages can and should use different colours for contrast.
+        /// </summary>
+        /// <param name="foregroundColor">The colour of the text to write.</param>
+        /// <param name="value">The value to write.</param>
         public static void WriteLine(ConsoleColor foregroundColor, string? value)
         {
             System.Console.ForegroundColor = foregroundColor;


### PR DESCRIPTION
Pushes extra items to the queue after setting the new schema version, to pick up scores that might get missed during a switchover.

closes #116