### PR TITLE
Store versions being processed in redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Component for loading [osu!](https://osu.ppy.sh) scores into Elasticsearch.
 
 ## Elasticsearch 8 compatiblity
 
-Requires minimum Elasticsearch 8.2.
+If using Elasticsearch 8, a minimum version of Elasticsearch 8.2 is required.
 
 The following env needs to be set on the indexer:
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ This will enable http connections to elasticsearch and disable the https and aut
 
 A string value is used to indicate the current schema version to be used.
 
+When the queue processor is running, it will store the version it is processing in a set in Redis at `osu-queue:score-index:${prefix}active-schemas`.
+
+If a queue processor is stops automatically due to a schema version change,
+it will remove the version it is processing from the set of versions; it _will not_ be removed if the processor if stopped manually or from processor failures; this is to allow other services to continue pushing to those queues.
+
 ## Adding items to be indexed
 
 Scores with `preserve`=`true` belonging to a user with `user_warnings`=`0` will be added to the index,
@@ -49,7 +54,7 @@ Push items to `osu-queue:score-index-${schema}`
 
 ## Switching to a new schema
 
-Run `dotnet run schema --schema ${schema}` or set `osu-queue:score-index:schema` directly in Redis
+Run `dotnet run schema --schema ${schema}` or set `osu-queue:score-index:${prefix}schema` directly in Redis
 
 ### Automatic index switching
 
@@ -169,6 +174,20 @@ Extra options:
 `--from {id}`: `solo_scores.id` to start reading from
 
 `--switch`: Sets the schema version after the last item is queued; it does not wait for the item to be indexed; this option is provided as a conveninence for testing.
+
+## Listing known versions currently being processed
+
+    dotnet run active-schemas
+
+will list the versions known to have queue processors listening on the queue.
+
+
+## Manually add or remove known versions
+
+For debugging purposes or to perform and manual maintenance or cleanups, the list of versions can be updated manually:
+
+    dotnet run active-schemas add ${schema}
+    dotnet run active-schemas remove ${schema}
 
 # (Re)Populating an index
 

--- a/osu.ElasticIndexer/Commands/ActiveSchemasAddCommand.cs
+++ b/osu.ElasticIndexer/Commands/ActiveSchemasAddCommand.cs
@@ -18,11 +18,9 @@ namespace osu.ElasticIndexer.Commands
         public int OnExecute(CancellationToken token)
         {
             var added = new Redis().AddActiveSchema(Schema);
+            var text = added ? "Added" : "Already exists";
 
-            if (added)
-                Console.WriteLine(ConsoleColor.Green, $"Added: {Schema}");
-            else
-                Console.WriteLine(ConsoleColor.Green, $"Already exists: {Schema}");
+            Console.WriteLine(ConsoleColor.Green, $"{text}: {Schema}");
 
             return 0;
         }

--- a/osu.ElasticIndexer/Commands/ActiveSchemasAddCommand.cs
+++ b/osu.ElasticIndexer/Commands/ActiveSchemasAddCommand.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace osu.ElasticIndexer.Commands
+{
+    [Command("add", Description = "Add a schema version to the list of versions being processed.")]
+    public class ActiveSchemasAddCommand
+    {
+        [Argument(0)]
+        [Required]
+        public string Schema { get; set; } = string.Empty;
+
+        public int OnExecute(CancellationToken token)
+        {
+            var added = new Redis().AddActiveSchema(Schema);
+
+            if (added)
+                Console.WriteLine(ConsoleColor.Green, $"Added: {Schema}");
+            else
+                Console.WriteLine(ConsoleColor.Green, $"Already exists: {Schema}");
+
+            return 0;
+        }
+    }
+}

--- a/osu.ElasticIndexer/Commands/ActiveSchemasCommand.cs
+++ b/osu.ElasticIndexer/Commands/ActiveSchemasCommand.cs
@@ -15,10 +15,11 @@ namespace osu.ElasticIndexer.Commands
         {
             var value = new Redis().GetActiveSchemas();
 
-            if (value.Length == 0)
-                Console.WriteLine("No known schema versions currently being processed.");
-            else
-                Console.WriteLine($"Schema versions currently being processed: {string.Join(", ", value)}");
+            Console.WriteLine(
+                value.Length == 0
+                ? "No known schema versions currently being processed."
+                : $"Schema versions currently being processed: {string.Join(", ", value)}"
+            );
 
             return 0;
         }

--- a/osu.ElasticIndexer/Commands/ActiveSchemasCommand.cs
+++ b/osu.ElasticIndexer/Commands/ActiveSchemasCommand.cs
@@ -17,8 +17,8 @@ namespace osu.ElasticIndexer.Commands
 
             Console.WriteLine(
                 value.Length == 0
-                ? "No known schema versions currently being processed."
-                : $"Schema versions currently being processed: {string.Join(", ", value)}"
+                    ? "No known schema versions currently being processed."
+                    : $"Schema versions currently being processed: {string.Join(", ", value)}"
             );
 
             return 0;

--- a/osu.ElasticIndexer/Commands/ActiveSchemasCommand.cs
+++ b/osu.ElasticIndexer/Commands/ActiveSchemasCommand.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace osu.ElasticIndexer.Commands
+{
+    [Command("active-schemas", Description = "Lists known schema versions being processed.")]
+    [Subcommand(typeof(ActiveSchemasAddCommand))]
+    [Subcommand(typeof(ActiveSchemasRemoveCommand))]
+    public class ActiveSchemasCommand
+    {
+        public int OnExecute(CancellationToken token)
+        {
+            var value = new Redis().GetActiveSchemas();
+
+            if (value.Length == 0)
+                Console.WriteLine("No known schema versions currently being processed.");
+            else
+                Console.WriteLine($"Schema versions currently being processed: {string.Join(", ", value)}");
+
+            return 0;
+        }
+    }
+}

--- a/osu.ElasticIndexer/Commands/ActiveSchemasRemoveCommand.cs
+++ b/osu.ElasticIndexer/Commands/ActiveSchemasRemoveCommand.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace osu.ElasticIndexer.Commands
+{
+    [Command("remove", Description = "Removes a schema version from the list of versions being processed.")]
+    public class ActiveSchemasRemoveCommand
+    {
+        [Argument(0)]
+        [Required]
+        public string Schema { get; set; } = string.Empty;
+
+        public int OnExecute(CancellationToken token)
+        {
+            var exists = new Redis().RemoveActiveSchema(Schema);
+
+            if (exists)
+                Console.WriteLine(ConsoleColor.Green, $"Removed: {Schema}");
+            else
+                Console.WriteLine(ConsoleColor.Green, $"Did not exist: {Schema}");
+
+            return 0;
+        }
+    }
+}

--- a/osu.ElasticIndexer/Commands/ActiveSchemasRemoveCommand.cs
+++ b/osu.ElasticIndexer/Commands/ActiveSchemasRemoveCommand.cs
@@ -18,11 +18,9 @@ namespace osu.ElasticIndexer.Commands
         public int OnExecute(CancellationToken token)
         {
             var exists = new Redis().RemoveActiveSchema(Schema);
+            var text = exists ? "Removed" : "Did not exist";
 
-            if (exists)
-                Console.WriteLine(ConsoleColor.Green, $"Removed: {Schema}");
-            else
-                Console.WriteLine(ConsoleColor.Green, $"Did not exist: {Schema}");
+            Console.WriteLine(ConsoleColor.Green, $"{text}: {Schema}");
 
             return 0;
         }

--- a/osu.ElasticIndexer/IndexQueueProcessor.cs
+++ b/osu.ElasticIndexer/IndexQueueProcessor.cs
@@ -21,9 +21,9 @@ namespace osu.ElasticIndexer
 
         // QueueProcessor doesn't expose cancellation without overriding Run,
         // so we're making use of a supplied callback to stop processing.
-        private readonly Action stop;
+        private readonly Action<bool> stop;
 
-        internal IndexQueueProcessor(string index, Client client, Action stopCallback)
+        internal IndexQueueProcessor(string index, Client client, Action<bool> stopCallback)
             : base(new QueueConfiguration
             {
                 InputQueueName = queue_name,
@@ -110,7 +110,7 @@ namespace osu.ElasticIndexer
                     item.Failed = true;
                 }
 
-                stop();
+                stop(true);
                 return;
             }
 
@@ -140,7 +140,7 @@ namespace osu.ElasticIndexer
                     item.Failed = true;
                 }
 
-                stop();
+                stop(true);
             }
 
             // TODO: per-item errors?

--- a/osu.ElasticIndexer/IndexQueueProcessor.cs
+++ b/osu.ElasticIndexer/IndexQueueProcessor.cs
@@ -21,9 +21,9 @@ namespace osu.ElasticIndexer
 
         // QueueProcessor doesn't expose cancellation without overriding Run,
         // so we're making use of a supplied callback to stop processing.
-        private readonly Action<bool> stop;
+        private readonly Action stop;
 
-        internal IndexQueueProcessor(string index, Client client, Action<bool> stopCallback)
+        internal IndexQueueProcessor(string index, Client client, Action stopCallback)
             : base(new QueueConfiguration
             {
                 InputQueueName = queue_name,
@@ -110,7 +110,7 @@ namespace osu.ElasticIndexer
                     item.Failed = true;
                 }
 
-                stop(true);
+                stop();
                 return;
             }
 
@@ -140,7 +140,7 @@ namespace osu.ElasticIndexer
                     item.Failed = true;
                 }
 
-                stop(true);
+                stop();
             }
 
             // TODO: per-item errors?

--- a/osu.ElasticIndexer/Program.cs
+++ b/osu.ElasticIndexer/Program.cs
@@ -8,6 +8,7 @@ using osu.ElasticIndexer.Commands;
 namespace osu.ElasticIndexer
 {
     [Command]
+    [Subcommand(typeof(ActiveSchemasCommand))]
     [Subcommand(typeof(ClearQueueCommand))]
     [Subcommand(typeof(CloseIndexCommand))]
     [Subcommand(typeof(DeleteIndexCommand))]

--- a/osu.ElasticIndexer/Redis.cs
+++ b/osu.ElasticIndexer/Redis.cs
@@ -7,24 +7,40 @@ namespace osu.ElasticIndexer
 {
     public class Redis
     {
-        private readonly string key = $"osu-queue:score-index:{AppSettings.Prefix}schema";
+        private readonly string activeSchemasKey = $"osu-queue:score-index:{AppSettings.Prefix}active-schemas";
+        private readonly string schemaKey = $"osu-queue:score-index:{AppSettings.Prefix}schema";
 
         public readonly ConnectionMultiplexer Connection = ConnectionMultiplexer.Connect(AppSettings.RedisHost);
 
+        public bool AddActiveSchema(string value)
+        {
+            return Connection.GetDatabase().SetAdd(activeSchemasKey, value);
+        }
+
         public void ClearSchemaVersion()
         {
-            Connection.GetDatabase().KeyDelete(key);
+            Connection.GetDatabase().KeyDelete(schemaKey);
+        }
+
+        public string[] GetActiveSchemas()
+        {
+            return Connection.GetDatabase().SetMembers(activeSchemasKey).ToStringArray();
         }
 
         public string GetSchemaVersion()
         {
-            var value = Connection.GetDatabase().StringGet(key);
+            var value = Connection.GetDatabase().StringGet(schemaKey);
             return value.IsNullOrEmpty ? string.Empty : value.ToString();
+        }
+
+        public bool RemoveActiveSchema(string value)
+        {
+            return Connection.GetDatabase().SetRemove(activeSchemasKey, value);
         }
 
         public void SetSchemaVersion(string value)
         {
-            Connection.GetDatabase().StringSet(key, value);
+            Connection.GetDatabase().StringSet(schemaKey, value);
         }
     }
 }

--- a/osu.ElasticIndexer/SoloScoreIndexer.cs
+++ b/osu.ElasticIndexer/SoloScoreIndexer.cs
@@ -35,13 +35,10 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public void Stop(bool aborted)
+        public void Stop()
         {
             if (cts == null || cts.IsCancellationRequested)
                 return;
-
-            if (!aborted)
-                redis.RemoveActiveSchema(AppSettings.Schema);
 
             cts.Cancel();
         }
@@ -72,7 +69,8 @@ namespace osu.ElasticIndexer
             }
 
             Console.WriteLine(ConsoleColor.Yellow, $"Previous schema {previousSchema}, got {schema}, need {AppSettings.Schema}, exiting...");
-            Stop(false);
+            redis.RemoveActiveSchema(AppSettings.Schema);
+            Stop();
         }
     }
 }

--- a/osu.ElasticIndexer/SoloScoreIndexer.cs
+++ b/osu.ElasticIndexer/SoloScoreIndexer.cs
@@ -28,6 +28,8 @@ namespace osu.ElasticIndexer
 
                 checkSchema();
 
+                redis.AddActiveSchema(AppSettings.Schema);
+
                 using (new Timer(_ => checkSchema(), null, TimeSpan.Zero, TimeSpan.FromSeconds(5)))
                     new IndexQueueProcessor(metadata.Name, client, Stop).Run(cts.Token);
             }
@@ -67,6 +69,7 @@ namespace osu.ElasticIndexer
             }
 
             Console.WriteLine(ConsoleColor.Yellow, $"Previous schema {previousSchema}, got {schema}, need {AppSettings.Schema}, exiting...");
+            redis.RemoveActiveSchema(AppSettings.Schema);
             Stop();
         }
     }

--- a/osu.ElasticIndexer/SoloScoreIndexer.cs
+++ b/osu.ElasticIndexer/SoloScoreIndexer.cs
@@ -35,10 +35,13 @@ namespace osu.ElasticIndexer
             }
         }
 
-        public void Stop()
+        public void Stop(bool aborted)
         {
             if (cts == null || cts.IsCancellationRequested)
                 return;
+
+            if (!aborted)
+                redis.RemoveActiveSchema(AppSettings.Schema);
 
             cts.Cancel();
         }
@@ -69,8 +72,7 @@ namespace osu.ElasticIndexer
             }
 
             Console.WriteLine(ConsoleColor.Yellow, $"Previous schema {previousSchema}, got {schema}, need {AppSettings.Schema}, exiting...");
-            redis.RemoveActiveSchema(AppSettings.Schema);
-            Stop();
+            Stop(false);
         }
     }
 }


### PR DESCRIPTION
closes #118

Just stores the versions in a redis set. The processor will remove itself from the list if it stops automatically from a detected version change, otherwise it will leave the version in the list.

Also updated the readme to be more specific about the Elasticsearch 8.2 requirement applying only to 8