### PR TITLE
Move organizing buffer items into ProcessableItemsBuffer construction

### DIFF
--- a/osu.ElasticIndexer/ProcessableItemsBuffer.cs
+++ b/osu.ElasticIndexer/ProcessableItemsBuffer.cs
@@ -1,18 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 
 namespace osu.ElasticIndexer
 {
     public class ProcessableItemsBuffer
     {
-        /// <summary>
-        /// A set of all score IDs which have arrived but are not yet determined to be an addition or deletion.
-        /// These should be processed into either <see cref="Additions"/> or <see cref="Deletions"/>.
-        /// </summary>
-        public readonly HashSet<long> ScoreIdsForLookup = new HashSet<long>();
-
         /// <summary>
         /// New scores which should be indexed.
         /// </summary>
@@ -22,5 +19,60 @@ namespace osu.ElasticIndexer
         /// Score IDs which should be purged from the index is they are present.
         /// </summary>
         public readonly List<long> Deletions = new List<long>();
+
+        /// <summary>
+        /// A set of all score IDs which have arrived but are not yet determined to be an addition or deletion.
+        /// These should be processed into either <see cref="Additions"/> or <see cref="Deletions"/>.
+        /// </summary>
+        private readonly HashSet<long> scoreIdsForLookup = new HashSet<long>();
+
+        public ProcessableItemsBuffer(IEnumerable<ScoreItem> items)
+        {
+            // Figure out what to do with the queue item.
+            foreach (var item in items)
+            {
+                if (item.ScoreId != null)
+                {
+                    scoreIdsForLookup.Add(item.ScoreId.Value);
+                }
+                else if (item.Score != null)
+                {
+                    if (item.Score.ShouldIndex)
+                        Additions.Add(item.Score);
+                    else
+                        Deletions.Add(item.Score.id);
+                }
+                else
+                {
+                    Console.WriteLine(ConsoleColor.Red, "queue item missing both data and action");
+                }
+            }
+
+            // Handle any scores that need a lookup from the database.
+            performDatabaseLookup();
+
+            Debug.Assert(scoreIdsForLookup.Count == 0);
+        }
+
+        private void performDatabaseLookup()
+        {
+            if (!scoreIdsForLookup.Any()) return;
+
+            var scores = ElasticModel.Find<SoloScore>(scoreIdsForLookup);
+
+            foreach (var score in scores)
+            {
+                if (score.ShouldIndex)
+                    Additions.Add(score);
+                else
+                    Deletions.Add(score.id);
+
+                scoreIdsForLookup.Remove(score.id);
+            }
+
+            // Remaining scores do not exist and should be deleted.
+            Deletions.AddRange(scoreIdsForLookup);
+            scoreIdsForLookup.Clear();
+        }
     }
 }


### PR DESCRIPTION
Some cleanup while looking at the error handling.

Logically separate the organizing and lookup away from the processor class.
Processor can just focus on dispatching.