### PR TITLE
Add id to schema's sort option for tie breaker

### DIFF
--- a/osu.ElasticIndexer/schemas/solo_scores.json
+++ b/osu.ElasticIndexer/schemas/solo_scores.json
@@ -70,8 +70,8 @@
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "sort": {
-        "field": "total_score",
-        "order": "desc"
+        "field": ["total_score", "id"],
+        "order": ["desc", "asc"]
       }
     }
   }


### PR DESCRIPTION
Speeding up the most basic leaderboard query.