### PR TITLE
Update env var names to all caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,13 @@ When the schema version changes, all indexers processing the queues for any othe
 Configuration is loaded from environment variables. No environment files are automatically loaded.
 
 To read environment variables from an env file, you can prefix the command to run with `env $(cat {envfile})` replacing `{envfile}` with your env file, e.g.
+> Note that this method of passing envvars does not support values with spaces.
 
     env $(cat .env) dotnet run
 
-additional envs can be set:
+Additional envs can be set:
 
     env $(cat .env) schema=1 dotnet run
-
-envvars with spaces are not supported.
 
 # Commands
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To read environment variables from an env file, you can prefix the command to ru
 
 Additional envs can be set:
 
-    env $(cat .env) schema=1 dotnet run
+    env $(cat .env) SCHEMA=1 dotnet run
 
 ## Environment Variables
 
@@ -124,11 +124,11 @@ in cases where `dotnet run` is not available, the assembly should be used, e.g. 
 Running `queue` will automatically create an index if an open index matching the requested `schema` does not exist.
 If a matching open index exists, it will be reused.
 
-    schema=${schema} dotnet run queue
+    SCHEMA=${schema} dotnet run queue
 
 e.g.
 
-    schema=1 dotnet run queue
+    SCHEMA=1 dotnet run queue
 
 ## Getting the current schema version
 
@@ -183,13 +183,13 @@ Passing arguments to the command will delete the matching index:
 
 For testing purposes, we can add fake items to the queue:
 
-    schema=1 dotnet run fake
+    SCHEMA=1 dotnet run fake
 
 It should be noted that these items will not exist or match the ones in the database.
 
 ## Queuing a specific score for indexing
 
-    schema=${schema} dotnet run index ${id}
+    SCHEMA=${schema} dotnet run index ${id}
 
 will queue the score with `${id}` for indexing; the score will be added or deleted as necessary, according to the value of `SoloScore.ShouldIndex`.
 
@@ -197,7 +197,7 @@ See [Queuing items for processing from another client](#queuing-items-for-proces
 
 ## Adding existing database records to the queue
 
-    schema=1 dotnet run all
+    SCHEMA=1 dotnet run all
 
 will read existing `solo_scores` in chunks and add them to the queue for indexing. Only scores with a corresponding `phpbb_users` entry will be queued.
 
@@ -229,7 +229,7 @@ Populating an index is done by pushing score items to a queue.
 
     docker build -t ${tagname} -f osu.ElasticIndexer/Dockerfile osu.ElasticIndexer
 
-    docker run -e schema=1 -e "ES_HOST=http://host.docker.internal:9200" -e "prefix=docker." -e "REDIS_HOST=host.docker.internal" -e "DB_CONNECTION_STRING=Server=host.docker.internal;Database=osu;Uid=osuweb;SslMode=None;" ${tagname} ${cmd}
+    docker run -e SCHEMA=1 -e "ES_HOST=http://host.docker.internal:9200" -e "ES_INDEX_PREFIX=docker." -e "REDIS_HOST=host.docker.internal" -e "DB_CONNECTION_STRING=Server=host.docker.internal;Database=osu;Uid=osuweb;SslMode=None;" ${tagname} ${cmd}
 
 where `${cmd}` is the command to run, e.g. `dotnet osu.ElasticIndexer.dll queue`
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,39 @@ Additional envs can be set:
 
     env $(cat .env) schema=1 dotnet run
 
+## Environment Variables
+
+### BATCH_SIZE
+Maximum number of items to handle/dequeue per batch. This affects the size of the `_bulk` request sent to Elasticsearch.
+
+Defaults to `10000`.
+
+### BUFFER_SIZE
+
+Maximum number of `BATCH_SIZE * BUFFER_SIZE` items allowed inflight during queue processing.
+
+Defaults to `5` (default of `50000` items).
+
+### DB_CONNECTION_STRING
+Connection string for the database connection.
+Standard `MySqlConnector` connection string.
+
+### ES_INDEX_PREFIX
+Optional prefix for the index names in elasticsearch.
+
+### ES_HOST
+Url to the Elasticsearch host.
+
+Defaults to `http://elasticsearch:9200`
+
+### REDIS_HOST
+Redis connection string; see [here](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#configuration-options) for configuration options.
+
+Defaults to `redis`
+
+### SCHEMA
+Schema version for the queue; see [Schema](#schema).
+
 # Commands
 
 This documentation assumes `dotnet run` can be used;

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -9,17 +9,17 @@ namespace osu.ElasticIndexer
     {
         static AppSettings()
         {
-            string? batchSize = Environment.GetEnvironmentVariable("batch_size");
+            string? batchSize = Environment.GetEnvironmentVariable("BATCH_SIZE");
             if (!string.IsNullOrEmpty(batchSize))
                 BatchSize = int.Parse(batchSize);
 
-            string? bufferSize = Environment.GetEnvironmentVariable("buffer_size");
+            string? bufferSize = Environment.GetEnvironmentVariable("BUFFER_SIZE");
             if (!string.IsNullOrEmpty(bufferSize))
                 BufferSize = int.Parse(bufferSize);
 
             ConnectionString = Environment.GetEnvironmentVariable("DB_CONNECTION_STRING") ?? string.Empty;
-            Schema = Environment.GetEnvironmentVariable("schema") ?? string.Empty;
-            Prefix = Environment.GetEnvironmentVariable("prefix") ?? string.Empty;
+            Schema = Environment.GetEnvironmentVariable("SCHEMA") ?? string.Empty;
+            Prefix = Environment.GetEnvironmentVariable("ES_INDEX_PREFIX") ?? string.Empty;
             ElasticsearchHost = Environment.GetEnvironmentVariable("ES_HOST") ?? "http://elasticsearch:9200";
             RedisHost = Environment.GetEnvironmentVariable("REDIS_HOST") ?? "redis";
         }


### PR DESCRIPTION
Use all caps env names to be consistent with everything else.
`prefix` changed to `ES_INDEX_PREFIX` to match osu-web.