### PR TITLE
🔥 Remove unnecessary bloat in Docker image

### DIFF
--- a/osu.ElasticIndexer/Dockerfile
+++ b/osu.ElasticIndexer/Dockerfile
@@ -1,15 +1,18 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /app
 
+# Copy csproj and restore as distinct layers
 COPY *.csproj ./
-
 RUN dotnet restore
 
+# Copy everything else and build
 COPY . ./
 RUN dotnet publish -c Release -o out
+# get rid of bloat
+RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll ./out/osuTK.dll
 
+# Build runtime image
 FROM mcr.microsoft.com/dotnet/runtime:6.0
-
 WORKDIR /app
 COPY --from=build-env /app/out .
 COPY docker docker


### PR DESCRIPTION
These files are massive and unused in a headless context. Same workaround as applied in osu-difficulty-calculator. Seems to run fine.

Also added comments as per other repos