### PR TITLE
Increase default number of shards to 4

### DIFF
--- a/osu.ElasticIndexer/schemas/solo_scores.json
+++ b/osu.ElasticIndexer/schemas/solo_scores.json
@@ -70,7 +70,7 @@
   },
   "settings": {
     "index": {
-      "number_of_shards": "1",
+      "number_of_shards": "4",
       "number_of_replicas": "0",
       "sort": {
         "field": ["is_legacy", "total_score", "id"],


### PR DESCRIPTION
Turns out there's a lucene limit of 2^31 documents per shard 💦 

Probably should look at being able to supply extra flags for overriding index creation settings in the future.