### PR TITLE
Add safety in `PumpAllScores` to avoid potentially running redis into the ground

### DIFF
--- a/osu.ElasticIndexer/Commands/PumpAllScoresCommand.cs
+++ b/osu.ElasticIndexer/Commands/PumpAllScoresCommand.cs
@@ -79,6 +79,12 @@ namespace osu.ElasticIndexer.Commands
 
                 Console.WriteLine($"Pushing {scoreItems.Count} scores");
 
+                while (Processor.GetQueueSize() > 1000000)
+                {
+                    System.Console.WriteLine($"Paused due to excessive queue length ({Processor.GetQueueSize()})");
+                    Thread.Sleep(30000);
+                }
+
                 Processor.PushToQueue(scoreItems);
 
                 Console.WriteLine($"Pushed {scores.LastOrDefault()}");


### PR DESCRIPTION
As happened on production recently.