### PR TITLE
Default all external services to `localhost`

### DIFF
--- a/osu.ElasticIndexer/.env.example
+++ b/osu.ElasticIndexer/.env.example
@@ -1,3 +1,3 @@
 DB_CONNECTION_STRING="Server=localhost;Database=osu;Uid=username;SslMode=None;"
-ES_HOST=http://elasticsearch:9200
+ES_HOST=http://localhost:9200
 REDIS_HOST=redis

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -20,8 +20,8 @@ namespace osu.ElasticIndexer
             ConnectionString = Environment.GetEnvironmentVariable("DB_CONNECTION_STRING") ?? string.Empty;
             Schema = Environment.GetEnvironmentVariable("SCHEMA") ?? string.Empty;
             Prefix = Environment.GetEnvironmentVariable("ES_INDEX_PREFIX") ?? string.Empty;
-            ElasticsearchHost = Environment.GetEnvironmentVariable("ES_HOST") ?? "http://elasticsearch:9200";
-            RedisHost = Environment.GetEnvironmentVariable("REDIS_HOST") ?? "redis";
+            ElasticsearchHost = Environment.GetEnvironmentVariable("ES_HOST") ?? "http://localhost:9200";
+            RedisHost = Environment.GetEnvironmentVariable("REDIS_HOST") ?? "localhost";
         }
 
         public static int BufferSize { get; } = 5;


### PR DESCRIPTION
In line with https://github.com/ppy/osu-queue-processor/pull/22. Simplifies documentation and deployment considerations.