### PR TITLE
Build image for arm64 platform

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           context: ./osu.ElasticIndexer
           file: ./osu.ElasticIndexer/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
same deal as ppy/osu-notification-server#52

For some reason docker also refuses to try the amd64 versions without setting the platform explicitly, unlike `osu-beatmap-difficulty-lookup-cache` unless something has changed in the packaging or aspnet is different 🤷 