### PR TITLE
Attempt to fix memory leak

### DIFF
--- a/osu.ElasticIndexer/IndexQueueProcessor.cs
+++ b/osu.ElasticIndexer/IndexQueueProcessor.cs
@@ -40,7 +40,10 @@ namespace osu.ElasticIndexer
 
         protected override void ProcessResults(IEnumerable<ScoreItem> items)
         {
-            var buffer = new ProcessableItemsBuffer(items);
+            ProcessableItemsBuffer buffer;
+
+            using (var conn = GetDatabaseConnection())
+                buffer = new ProcessableItemsBuffer(conn, items);
 
             if (buffer.Additions.Any() || buffer.Deletions.Any())
             {


### PR DESCRIPTION
Just a quick attempt to fix (without yet closing) https://github.com/ppy/osu-elastic-indexer/issues/144.

As a note, I can't reproduce this.

The thinking is that there's some MYSQL parameter/redis parameter/ES parameter that keeps connections open, and this was previously creating a new Redis connection and new `DogstatsdService` every time via `QueueProcessor<T>`, as well as not disposing the MYSQL connection.

Note that `QueueProcessor<T>` doesn't have a `Dispose()` which is a bit of an issue itself, but I don't think this particular code path should be creating a new one every time in any case.