### PR TITLE
Fix serialisation failures due to model serialisation changes

### DIFF
--- a/osu.ElasticIndexer/Commands/Queue/PumpAllScoresCommand.cs
+++ b/osu.ElasticIndexer/Commands/Queue/PumpAllScoresCommand.cs
@@ -66,20 +66,20 @@ namespace osu.ElasticIndexer.Commands.Queue
             using (var mySqlConnection = processor.GetDatabaseConnection())
 
             {
-                var chunks = ElasticModel.Chunk<SoloScore>(mySqlConnection, "preserve = 1", AppSettings.BatchSize, from);
-                SoloScore? last = null;
+                var chunks = ElasticModel.Chunk<Score>(mySqlConnection, "preserve = 1", AppSettings.BatchSize, from);
+                Score? last = null;
 
                 foreach (var scores in chunks)
                 {
                     if (cancellationToken.IsCancellationRequested)
                         break;
 
-                    List<ScoreItem> scoreItems = new List<ScoreItem>();
+                    List<ScoreQueueItem> scoreItems = new List<ScoreQueueItem>();
 
                     foreach (var score in scores)
                     {
                         score.country_code ??= "XX";
-                        scoreItems.Add(new ScoreItem { Score = score });
+                        scoreItems.Add(new ScoreQueueItem { Score = score });
                     }
 
                     Console.WriteLine($"Pushing {scoreItems.Count} scores");

--- a/osu.ElasticIndexer/Commands/Queue/PumpFakeScoresCommand.cs
+++ b/osu.ElasticIndexer/Commands/Queue/PumpFakeScoresCommand.cs
@@ -21,7 +21,7 @@ namespace osu.ElasticIndexer.Commands.Queue
             while (!cancellationToken.IsCancellationRequested)
             {
                 var score =
-                    new SoloScore
+                    new Score
                     {
                         // TODO: better random data
                         data = @"{
@@ -56,7 +56,7 @@ namespace osu.ElasticIndexer.Commands.Queue
                         preserve = true
                     };
 
-                processor.PushToQueue(new ScoreItem { Score = score });
+                processor.PushToQueue(new ScoreQueueItem { Score = score });
 
                 if (counter % 1000 == 0)
                     Console.WriteLine($"pushed to {processor.QueueName}, current id: {counter}");

--- a/osu.ElasticIndexer/Commands/Queue/PumpScoreCommand.cs
+++ b/osu.ElasticIndexer/Commands/Queue/PumpScoreCommand.cs
@@ -20,7 +20,7 @@ namespace osu.ElasticIndexer.Commands.Queue
             var processor = new UnrunnableProcessor();
 
             var id = long.Parse(ScoreId);
-            var scoreItem = new ScoreItem { ScoreId = id };
+            var scoreItem = new ScoreQueueItem { ScoreId = id };
             processor.PushToQueue(scoreItem);
 
             Console.WriteLine(ConsoleColor.Green, $"Queued to {processor.QueueName}: {scoreItem}");

--- a/osu.ElasticIndexer/IndexQueueProcessor.cs
+++ b/osu.ElasticIndexer/IndexQueueProcessor.cs
@@ -10,7 +10,7 @@ using osu.Server.QueueProcessor;
 
 namespace osu.ElasticIndexer
 {
-    public class IndexQueueProcessor : QueueProcessor<ScoreItem>
+    public class IndexQueueProcessor : QueueProcessor<ScoreQueueItem>
     {
         private static readonly string queue_name = $"score-index-{AppSettings.Schema}";
 
@@ -38,7 +38,7 @@ namespace osu.ElasticIndexer
                 throw new MissingSchemaException();
         }
 
-        protected override void ProcessResults(IEnumerable<ScoreItem> items)
+        protected override void ProcessResults(IEnumerable<ScoreQueueItem> items)
         {
             ProcessableItemsBuffer buffer;
 
@@ -54,14 +54,14 @@ namespace osu.ElasticIndexer
                                      .Index(index)
                                      .IndexMany(buffer.Additions)
                                      // type is needed for ids https://github.com/elastic/elasticsearch-net/issues/3500
-                                     .DeleteMany<SoloScore>(buffer.Deletions);
+                                     .DeleteMany<Score>(buffer.Deletions);
 
                 var response = elasticClient.Bulk(bulkDescriptor);
                 handleResponse(response, items);
             }
         }
 
-        private void handleResponse(BulkResponse response, IEnumerable<ScoreItem> items)
+        private void handleResponse(BulkResponse response, IEnumerable<ScoreQueueItem> items)
         {
             if (response.IsValid)
             {

--- a/osu.ElasticIndexer/ProcessableItemsBuffer.cs
+++ b/osu.ElasticIndexer/ProcessableItemsBuffer.cs
@@ -14,7 +14,7 @@ namespace osu.ElasticIndexer
         /// <summary>
         /// New scores which should be indexed.
         /// </summary>
-        public readonly List<SoloScore> Additions = new List<SoloScore>();
+        public readonly List<Score> Additions = new List<Score>();
 
         /// <summary>
         /// Score IDs which should be purged from the index is they are present.
@@ -27,7 +27,7 @@ namespace osu.ElasticIndexer
         /// </summary>
         private readonly HashSet<long> scoreIdsForLookup = new HashSet<long>();
 
-        public ProcessableItemsBuffer(MySqlConnection connection, IEnumerable<ScoreItem> items)
+        public ProcessableItemsBuffer(MySqlConnection connection, IEnumerable<ScoreQueueItem> items)
         {
             // Figure out what to do with the queue item.
             foreach (var item in items)
@@ -52,7 +52,7 @@ namespace osu.ElasticIndexer
             // Handle any scores that need a lookup from the database.
             if (scoreIdsForLookup.Any())
             {
-                var scores = ElasticModel.Find<SoloScore>(connection, scoreIdsForLookup);
+                var scores = ElasticModel.Find<Score>(connection, scoreIdsForLookup);
 
                 foreach (var score in scores)
                 {

--- a/osu.ElasticIndexer/ScoreQueueItem.cs
+++ b/osu.ElasticIndexer/ScoreQueueItem.cs
@@ -5,13 +5,13 @@ using osu.Server.QueueProcessor;
 
 namespace osu.ElasticIndexer
 {
-    public class ScoreItem : QueueItem
+    public class ScoreQueueItem : QueueItem
     {
         public long? ScoreId { get; init; }
 
         // ScoreId is always preferred if present (this property is ignored).
         // Note that this is generally not used anymore. Consider removing in the future unless a use case comes up?
-        public SoloScore? Score { get; init; }
+        public Score? Score { get; init; }
 
         public override string ToString() => Score != null ? $"ScoreItem Score: {Score.id}" : $"ScoreItem ScoreId: {ScoreId}";
     }

--- a/osu.ElasticIndexer/UnrunnableProcessor.cs
+++ b/osu.ElasticIndexer/UnrunnableProcessor.cs
@@ -6,7 +6,7 @@ using osu.Server.QueueProcessor;
 
 namespace osu.ElasticIndexer
 {
-    public class UnrunnableProcessor : QueueProcessor<ScoreItem>
+    public class UnrunnableProcessor : QueueProcessor<ScoreQueueItem>
     {
         private static readonly string queue_name = $"score-index-{AppSettings.Schema}";
 
@@ -17,7 +17,7 @@ namespace osu.ElasticIndexer
                 throw new MissingSchemaException();
         }
 
-        protected override void ProcessResult(ScoreItem item)
+        protected override void ProcessResult(ScoreQueueItem item)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Regressed with
https://github.com/ppy/osu/commit/900530080ff7f4c33a19b6107214c80ff4f0f997 as the interface implementations were being serialised, and failing on `Ruleset`'s serialisation because `Beatmap` is `null`.



![CleanShot 2023-12-08 at 04 46 50](https://github.com/ppy/osu-elastic-indexer/assets/191335/78a801e1-0eb2-4b72-a541-c0d1ddaca3ad)
