### PR TITLE
Add frequently filtered fields to index sorting

### DIFF
--- a/osu.ElasticIndexer/schemas/scores.json
+++ b/osu.ElasticIndexer/schemas/scores.json
@@ -73,8 +73,8 @@
       "number_of_shards": "2",
       "number_of_replicas": "0",
       "sort": {
-        "field": ["is_legacy", "total_score", "id"],
-        "order": ["asc", "desc", "asc"]
+        "field": ["is_legacy", "ruleset_id", "beatmap_id", "total_score", "id"],
+        "order": ["asc", "asc", "asc", "desc", "asc"]
       }
     }
   }


### PR DESCRIPTION
Still need to check how this impacts performance.

Quoting [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/index-modules-index-sorting-conjunctions.html):

> Index sorting can be useful in order to organize Lucene doc ids (not to be conflated with _id) in a way that makes conjunctions (a AND b AND …​) more efficient
> ...
> This trick only works with low-cardinality fields. A rule of thumb is that you should sort first on fields that both have a low cardinality and are frequently used for filtering