### PR TITLE
Use schema name as suffix

### DIFF
--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -40,5 +40,7 @@ namespace osu.ElasticIndexer
         public static string RedisHost { get; }
 
         public static string Schema { get; }
+
+        public static string AliasName { get; } = $"{AppSettings.Prefix}scores";
     }
 }

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -21,6 +21,7 @@ namespace osu.ElasticIndexer
             Prefix = Environment.GetEnvironmentVariable("ES_INDEX_PREFIX") ?? string.Empty;
             ElasticsearchHost = Environment.GetEnvironmentVariable("ES_HOST") ?? "http://localhost:9200";
             RedisHost = Environment.GetEnvironmentVariable("REDIS_HOST") ?? "localhost";
+            AliasName = $"{Prefix}scores";
 
             if (string.IsNullOrEmpty(Schema)) Console.WriteLine(ConsoleColor.Yellow, "WARNING: Running without SCHEMA envvar specification");
             if (!string.IsNullOrEmpty(Prefix)) Console.WriteLine(ConsoleColor.Yellow, $"WARNING: Running with PREFIX envvar specification ({Prefix})");
@@ -41,6 +42,6 @@ namespace osu.ElasticIndexer
 
         public static string Schema { get; }
 
-        public static string AliasName { get; } = $"{AppSettings.Prefix}scores";
+        public static string AliasName { get; }
     }
 }

--- a/osu.ElasticIndexer/AppSettings.cs
+++ b/osu.ElasticIndexer/AppSettings.cs
@@ -20,7 +20,6 @@ namespace osu.ElasticIndexer
             Schema = Environment.GetEnvironmentVariable("SCHEMA") ?? string.Empty;
             Prefix = Environment.GetEnvironmentVariable("ES_INDEX_PREFIX") ?? string.Empty;
             ElasticsearchHost = Environment.GetEnvironmentVariable("ES_HOST") ?? "http://localhost:9200";
-            RedisHost = Environment.GetEnvironmentVariable("REDIS_HOST") ?? "localhost";
             AliasName = $"{Prefix}scores";
 
             if (string.IsNullOrEmpty(Schema)) Console.WriteLine(ConsoleColor.Yellow, "WARNING: Running without SCHEMA envvar specification");
@@ -37,8 +36,6 @@ namespace osu.ElasticIndexer
         public static string ElasticsearchHost { get; }
 
         public static string Prefix { get; }
-
-        public static string RedisHost { get; }
 
         public static string Schema { get; }
 

--- a/osu.ElasticIndexer/Commands/Index/CloseIndexCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/CloseIndexCommand.cs
@@ -20,7 +20,7 @@ namespace osu.ElasticIndexer.Commands.Index
             if (base.OnExecute(token) != 0)
                 return -1;
 
-            var indices = string.IsNullOrEmpty(Name) ? ElasticClient.GetIndices(ElasticClient.AliasName) : ElasticClient.GetIndex(Name);
+            var indices = string.IsNullOrEmpty(Name) ? ElasticClient.GetIndices($"{ElasticClient.AliasName}_*") : ElasticClient.GetIndex(Name);
             var closeableIndices = indices.Where(entry => entry.Value.Aliases.Count == 0);
 
             if (!closeableIndices.Any())

--- a/osu.ElasticIndexer/Commands/Index/CloseIndexCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/CloseIndexCommand.cs
@@ -20,7 +20,8 @@ namespace osu.ElasticIndexer.Commands.Index
             if (base.OnExecute(token) != 0)
                 return -1;
 
-            var indices = string.IsNullOrEmpty(Name) ? ElasticClient.GetIndices($"{ElasticClient.AliasName}_*") : ElasticClient.GetIndex(Name);
+            var indices = string.IsNullOrEmpty(Name) ? ElasticClient.GetIndices($"{AppSettings.AliasName}_*") : ElasticClient.GetIndex(Name);
+
             var closeableIndices = indices.Where(entry => entry.Value.Aliases.Count == 0);
 
             if (!closeableIndices.Any())

--- a/osu.ElasticIndexer/Commands/Index/DeleteIndexCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/DeleteIndexCommand.cs
@@ -21,7 +21,7 @@ namespace osu.ElasticIndexer.Commands.Index
             if (base.OnExecute(token) != 0)
                 return -1;
 
-            string? index = string.IsNullOrEmpty(Name) ? $"{elasticClient.AliasName}_*" : Name;
+            string? index = string.IsNullOrEmpty(Name) ? $"{AppSettings.AliasName}_*" : Name;
             var response = elasticClient.Cat.Indices(x => x.Index(index));
             var closed = response.Records.Where(record => record.Status == "close");
 

--- a/osu.ElasticIndexer/Commands/Index/ListIndicesCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/ListIndicesCommand.cs
@@ -38,12 +38,9 @@ namespace osu.ElasticIndexer.Commands.Index
 
             foreach (var index in indices)
             {
-                var schema = index.Value.Mappings.Meta?["schema"];
-
                 var record = records.Single(r => r.Index == index.Key);
 
                 Console.WriteLine($"{record.Index} ({record.PrimaryStoreSize})\n"
-                                  + $"- schema version: {schema}\n"
                                   + $"- aliases: {string.Join(',', index.Value.Aliases.Select(a => a.Key))}\n"
                                   + $"- status: {record.Status}\n"
                                   + $"- docs: {record.DocsCount} ({record.DocsDeleted} deleted)\n");

--- a/osu.ElasticIndexer/Commands/Index/ListIndicesCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/ListIndicesCommand.cs
@@ -30,7 +30,7 @@ namespace osu.ElasticIndexer.Commands.Index
             Console.WriteLine($"Current schema: {currentSchema}");
             Console.WriteLine();
 
-            var indices = ElasticClient.GetIndices($"{ElasticClient.AliasName}_*");
+            var indices = ElasticClient.GetIndices($"{AppSettings.AliasName}_*");
             var records = ElasticClient.Cat.Indices(descriptor => descriptor.Index(Indices.All)).Records;
 
             Console.WriteLine($"# Elasticsearch indices ({indices.Count})");
@@ -65,7 +65,7 @@ namespace osu.ElasticIndexer.Commands.Index
                     return -1;
                 }
 
-                if (!currentIndex.Aliases.ContainsKey(ElasticClient.AliasName))
+                if (!currentIndex.Aliases.ContainsKey(AppSettings.AliasName))
                 {
                     Console.WriteLine(ConsoleColor.Red, "ERROR: Current schema is not aliased correctly");
                     return -1;

--- a/osu.ElasticIndexer/Commands/Index/ListIndicesCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/ListIndicesCommand.cs
@@ -62,9 +62,7 @@ namespace osu.ElasticIndexer.Commands.Index
 
             if (!string.IsNullOrEmpty(currentSchema))
             {
-                var currentIndex = indices.Select(i => i.Value).FirstOrDefault(i => (string?)i.Mappings.Meta?["schema"] == currentSchema);
-
-                if (currentIndex == null)
+                if (!indices.TryGetValue(currentSchema, out var currentIndex))
                 {
                     Console.WriteLine(ConsoleColor.Red, "ERROR: Current schema is not in present on elasticsearch");
                     return -1;

--- a/osu.ElasticIndexer/Commands/Index/ListIndicesCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/ListIndicesCommand.cs
@@ -30,7 +30,7 @@ namespace osu.ElasticIndexer.Commands.Index
             Console.WriteLine($"Current schema: {currentSchema}");
             Console.WriteLine();
 
-            var indices = ElasticClient.Indices.Get(Indices.All).Indices;
+            var indices = ElasticClient.GetIndices($"{ElasticClient.AliasName}_*");
             var records = ElasticClient.Cat.Indices(descriptor => descriptor.Index(Indices.All)).Records;
 
             Console.WriteLine($"# Elasticsearch indices ({indices.Count})");

--- a/osu.ElasticIndexer/Commands/Index/NukeAllIndicesCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/NukeAllIndicesCommand.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using McMaster.Extensions.CommandLineUtils;
-using Nest;
 using osu.Server.QueueProcessor;
 
 namespace osu.ElasticIndexer.Commands.Index;
@@ -13,11 +12,13 @@ public class NukeAllIndicesCommand : ListIndicesCommand
 {
     public override int OnExecute(CancellationToken token)
     {
+        string prefix = $"{ElasticClient.AliasName}_*";
+
         // Don't exit on error as we're likely trying to fix an error.
         base.OnExecute(token);
 
         Console.WriteLine();
-        Console.WriteLine("PREPARING TO NUKE ALL ELASTICSEARCH INDICES WITH FIRE!");
+        Console.WriteLine($"PREPARING TO NUKE ALL ELASTICSEARCH INDICES WITH PREFIX {prefix} WITH FIRE!");
         Console.WriteLine();
 
         Thread.Sleep(10000);
@@ -33,12 +34,12 @@ public class NukeAllIndicesCommand : ListIndicesCommand
 
         System.Console.WriteLine("Removing all indices..");
 
-        var records = ElasticClient.Cat.Indices(x => x.Index(Indices.All)).Records;
+        var indices = ElasticClient.GetIndices(prefix);
 
-        foreach (var record in records)
+        foreach (var index in indices)
         {
-            System.Console.WriteLine($"Deleting {record.Index}..");
-            ElasticClient.Indices.Delete(record.Index);
+            System.Console.WriteLine($"Deleting {index.Key}..");
+            ElasticClient.Indices.Delete(index.Key);
         }
 
         return 0;

--- a/osu.ElasticIndexer/Commands/Index/NukeAllIndicesCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/NukeAllIndicesCommand.cs
@@ -12,7 +12,7 @@ public class NukeAllIndicesCommand : ListIndicesCommand
 {
     public override int OnExecute(CancellationToken token)
     {
-        string prefix = $"{ElasticClient.AliasName}_*";
+        string prefix = $"{AppSettings.AliasName}_*";
 
         // Don't exit on error as we're likely trying to fix an error.
         base.OnExecute(token);

--- a/osu.ElasticIndexer/Commands/Index/UpdateAliasCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/UpdateAliasCommand.cs
@@ -40,7 +40,7 @@ namespace osu.ElasticIndexer.Commands.Index
             // TODO: should check if completed?
             string? indexName = index.Value.Key.Name;
 
-            ElasticClient.UpdateAlias(ElasticClient.AliasName, indexName, Close);
+            ElasticClient.UpdateAlias(AppSettings.AliasName, indexName, Close);
 
             Redis.SetCurrentSchema(indexName);
             return 0;

--- a/osu.ElasticIndexer/Commands/Index/UpdateAliasCommand.cs
+++ b/osu.ElasticIndexer/Commands/Index/UpdateAliasCommand.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Threading;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Server.QueueProcessor;
@@ -30,16 +29,16 @@ namespace osu.ElasticIndexer.Commands.Index
                 return 1;
             }
 
-            var indexStates = ElasticClient.GetIndicesForVersion(ElasticClient.AliasName, Schema);
+            var index = ElasticClient.GetIndexForSchema(Schema);
 
-            if (indexStates.Count == 0)
+            if (index == null)
             {
                 Console.WriteLine("No matching indices found.");
                 return 1;
             }
 
             // TODO: should check if completed?
-            string? indexName = indexStates.MaxBy(x => x.Key).Key.Name;
+            string? indexName = index.Value.Key.Name;
 
             ElasticClient.UpdateAlias(ElasticClient.AliasName, indexName, Close);
 

--- a/osu.ElasticIndexer/Commands/Queue/WatchQueueCommand.cs
+++ b/osu.ElasticIndexer/Commands/Queue/WatchQueueCommand.cs
@@ -13,14 +13,15 @@ namespace osu.ElasticIndexer.Commands.Queue
     {
         public int OnExecute(CancellationToken token)
         {
-            var schema = RedisAccess.GetConnection().GetCurrentSchema();
+            string currentIndex = RedisAccess.GetConnection().GetCurrentSchema();
+            string proposedIndex = $"{new OsuElasticClient().AliasName}_{AppSettings.Schema}";
 
-            if (string.IsNullOrEmpty(schema))
+            if (string.IsNullOrEmpty(currentIndex))
                 Console.WriteLine(ConsoleColor.Yellow, "WARNING: No current schema set, will set new schema as current");
-            else if (schema != AppSettings.Schema)
-                Console.WriteLine($"WARNING: Starting processing for schema version {AppSettings.Schema} which is not current (current schema is {schema})");
+            else if (currentIndex != proposedIndex)
+                Console.WriteLine($"WARNING: Starting processing for schema version {proposedIndex} which is not current (current schema is {currentIndex})");
 
-            Console.WriteLine(ConsoleColor.Green, $"Running queue with schema version {AppSettings.Schema}");
+            Console.WriteLine(ConsoleColor.Green, $"Running queue with schema version {proposedIndex}");
             Thread.Sleep(5000);
             if (token.IsCancellationRequested)
                 return -1;

--- a/osu.ElasticIndexer/Commands/Queue/WatchQueueCommand.cs
+++ b/osu.ElasticIndexer/Commands/Queue/WatchQueueCommand.cs
@@ -16,19 +16,9 @@ namespace osu.ElasticIndexer.Commands.Queue
             var schema = RedisAccess.GetConnection().GetCurrentSchema();
 
             if (string.IsNullOrEmpty(schema))
-            {
                 Console.WriteLine(ConsoleColor.Yellow, "WARNING: No current schema set, will set new schema as current");
-                Thread.Sleep(5000);
-                if (token.IsCancellationRequested)
-                    return -1;
-            }
             else if (schema != AppSettings.Schema)
-            {
                 Console.WriteLine($"WARNING: Starting processing for schema version {AppSettings.Schema} which is not current (current schema is {schema})");
-                Thread.Sleep(5000);
-                if (token.IsCancellationRequested)
-                    return -1;
-            }
 
             Console.WriteLine(ConsoleColor.Green, $"Running queue with schema version {AppSettings.Schema}");
             Thread.Sleep(5000);

--- a/osu.ElasticIndexer/Commands/Queue/WatchQueueCommand.cs
+++ b/osu.ElasticIndexer/Commands/Queue/WatchQueueCommand.cs
@@ -14,7 +14,7 @@ namespace osu.ElasticIndexer.Commands.Queue
         public int OnExecute(CancellationToken token)
         {
             string currentIndex = RedisAccess.GetConnection().GetCurrentSchema();
-            string proposedIndex = $"{new OsuElasticClient().AliasName}_{AppSettings.Schema}";
+            string proposedIndex = $"{AppSettings.AliasName}_{AppSettings.Schema}";
 
             if (string.IsNullOrEmpty(currentIndex))
                 Console.WriteLine(ConsoleColor.Yellow, "WARNING: No current schema set, will set new schema as current");

--- a/osu.ElasticIndexer/Commands/Queue/WatchQueueCommand.cs
+++ b/osu.ElasticIndexer/Commands/Queue/WatchQueueCommand.cs
@@ -17,13 +17,12 @@ namespace osu.ElasticIndexer.Commands.Queue
 
             if (string.IsNullOrEmpty(schema))
             {
-                Console.WriteLine(ConsoleColor.Yellow, "No current schema set, will set new schema as current");
+                Console.WriteLine(ConsoleColor.Yellow, "WARNING: No current schema set, will set new schema as current");
                 Thread.Sleep(5000);
                 if (token.IsCancellationRequested)
                     return -1;
             }
-
-            if (schema != AppSettings.Schema)
+            else if (schema != AppSettings.Schema)
             {
                 Console.WriteLine($"WARNING: Starting processing for schema version {AppSettings.Schema} which is not current (current schema is {schema})");
                 Thread.Sleep(5000);

--- a/osu.ElasticIndexer/IndexMetadata.cs
+++ b/osu.ElasticIndexer/IndexMetadata.cs
@@ -7,27 +7,16 @@ namespace osu.ElasticIndexer
 {
     public class IndexMetadata
     {
-        public readonly string Schema;
-
         public readonly string Name;
 
-        public IndexMetadata(string indexName, string schema)
-        {
-            Name = indexName;
-            Schema = schema;
-        }
-
-        public IndexMetadata(IndexName indexName, IndexState indexState)
+        public IndexMetadata(IndexName indexName)
         {
             Name = indexName.Name;
-            Schema = (string)indexState.Mappings.Meta["schema"];
         }
 
         public void Save(ElasticClient elasticClient)
         {
-            elasticClient.Map<SoloScoreIndexer>(mappings => mappings.Meta(
-                m => m.Add("schema", Schema)
-            ).Index(Name));
+            elasticClient.Map<SoloScoreIndexer>(mappings => mappings.Index(Name));
         }
     }
 }

--- a/osu.ElasticIndexer/IndexQueueProcessor.cs
+++ b/osu.ElasticIndexer/IndexQueueProcessor.cs
@@ -12,8 +12,6 @@ namespace osu.ElasticIndexer
 {
     public class IndexQueueProcessor : QueueProcessor<ScoreQueueItem>
     {
-        private static readonly string queue_name = $"score-index-{AppSettings.Schema}";
-
         private readonly OsuElasticClient elasticClient;
         private readonly string index;
 
@@ -24,7 +22,7 @@ namespace osu.ElasticIndexer
         internal IndexQueueProcessor(string index, OsuElasticClient elasticClient, Action stopCallback)
             : base(new QueueConfiguration
             {
-                InputQueueName = queue_name,
+                InputQueueName = $"{AppSettings.AliasName}_{AppSettings.Schema}",
                 BatchSize = AppSettings.BatchSize,
                 ErrorThreshold = AppSettings.BatchSize * 2, // needs to be larger than BatchSize to handle ES busy errors.
                 MaxInFlightItems = AppSettings.BatchSize * AppSettings.BufferSize

--- a/osu.ElasticIndexer/OsuElasticClient.cs
+++ b/osu.ElasticIndexer/OsuElasticClient.cs
@@ -27,7 +27,7 @@ namespace osu.ElasticIndexer
         /// </summary>
         /// <param name="name">name of the index alias.</param>
         /// <returns>Name of index found or created and any existing alias.</returns>
-        public IndexMetadata FindOrCreateIndex(string name)
+        public string FindOrCreateIndex(string name)
         {
             Console.WriteLine();
 
@@ -35,9 +35,9 @@ namespace osu.ElasticIndexer
 
             if (index != null)
             {
-                var (indexName, indexState) = index.Value;
+                string indexName = index.Value.Key.Name;
                 Console.WriteLine(ConsoleColor.Cyan, $"Using existing index `{indexName}`.");
-                return new IndexMetadata(indexName, indexState);
+                return indexName;
             }
 
             return createIndex(name);
@@ -88,7 +88,7 @@ namespace osu.ElasticIndexer
             }
         }
 
-        private IndexMetadata createIndex(string schema)
+        private string createIndex(string schema)
         {
             string name = $"{AliasName}_{schema}";
 
@@ -100,11 +100,10 @@ namespace osu.ElasticIndexer
                 json,
                 new CreateIndexRequestParameters { WaitForActiveShards = "all" }
             );
-            var metadata = new IndexMetadata(name, AppSettings.Schema);
 
-            metadata.Save(this);
+            Map<SoloScoreIndexer>(mappings => mappings.Index(name));
 
-            return metadata;
+            return name;
         }
     }
 }

--- a/osu.ElasticIndexer/OsuElasticClient.cs
+++ b/osu.ElasticIndexer/OsuElasticClient.cs
@@ -40,7 +40,7 @@ namespace osu.ElasticIndexer
                 return new IndexMetadata(indexName, indexState);
             }
 
-            return createIndex(index);
+            return createIndex(name);
         }
 
         public IReadOnlyDictionary<IndexName, IndexState> GetIndex(string name)
@@ -50,7 +50,7 @@ namespace osu.ElasticIndexer
 
         public IReadOnlyDictionary<IndexName, IndexState> GetIndices(string name, ExpandWildcards expandWildCards = ExpandWildcards.Open)
         {
-            return Indices.Get($"{name}_*", descriptor => descriptor.ExpandWildcards(expandWildCards)).Indices;
+            return Indices.Get(name, descriptor => descriptor.ExpandWildcards(expandWildCards)).Indices;
         }
 
         public KeyValuePair<IndexName, IndexState>? GetIndexForSchema(string schema)
@@ -88,19 +88,19 @@ namespace osu.ElasticIndexer
             }
         }
 
-        private IndexMetadata createIndex(string indexName)
+        private IndexMetadata createIndex(string schema)
         {
-            var index = $"{name}";
+            string name = $"{AliasName}_{schema}";
 
             Console.WriteLine(ConsoleColor.Cyan, $"Creating new index `{name}`.");
 
             var json = File.ReadAllText(Path.GetFullPath("schemas/scores.json"));
             LowLevel.Indices.Create<DynamicResponse>(
-                indexName,
+                name,
                 json,
                 new CreateIndexRequestParameters { WaitForActiveShards = "all" }
             );
-            var metadata = new IndexMetadata(indexName, AppSettings.Schema);
+            var metadata = new IndexMetadata(name, AppSettings.Schema);
 
             metadata.Save(this);
 

--- a/osu.ElasticIndexer/OsuElasticClient.cs
+++ b/osu.ElasticIndexer/OsuElasticClient.cs
@@ -13,8 +13,6 @@ namespace osu.ElasticIndexer
 {
     public class OsuElasticClient : ElasticClient
     {
-        public readonly string AliasName = $"{AppSettings.Prefix}scores";
-
         public OsuElasticClient(bool throwsExceptions = true)
             : base(new ConnectionSettings(new Uri(AppSettings.ElasticsearchHost))
                    .EnableApiVersioningHeader()
@@ -55,7 +53,7 @@ namespace osu.ElasticIndexer
 
         public KeyValuePair<IndexName, IndexState>? GetIndexForSchema(string schema)
         {
-            KeyValuePair<IndexName, IndexState>? index = GetIndices($"{AliasName}_{schema}")
+            KeyValuePair<IndexName, IndexState>? index = GetIndices($"{AppSettings.AliasName}_{schema}")
                 .SingleOrDefault();
 
             if (string.IsNullOrEmpty(index?.Key?.Name))
@@ -90,7 +88,7 @@ namespace osu.ElasticIndexer
 
         private string createIndex(string schema)
         {
-            string name = $"{AliasName}_{schema}";
+            string name = $"{AppSettings.AliasName}_{schema}";
 
             Console.WriteLine(ConsoleColor.Cyan, $"Creating new index `{name}`.");
 

--- a/osu.ElasticIndexer/OsuElasticClient.cs
+++ b/osu.ElasticIndexer/OsuElasticClient.cs
@@ -40,7 +40,7 @@ namespace osu.ElasticIndexer
                 return new IndexMetadata(indexName, indexState);
             }
 
-            return createIndex(name);
+            return createIndex(index);
         }
 
         public IReadOnlyDictionary<IndexName, IndexState> GetIndex(string name)
@@ -90,7 +90,9 @@ namespace osu.ElasticIndexer
 
         private IndexMetadata createIndex(string indexName)
         {
-            Console.WriteLine(ConsoleColor.Cyan, $"Creating new index `{indexName}`.");
+            var index = $"{name}";
+
+            Console.WriteLine(ConsoleColor.Cyan, $"Creating new index `{name}`.");
 
             var json = File.ReadAllText(Path.GetFullPath("schemas/scores.json"));
             LowLevel.Indices.Create<DynamicResponse>(

--- a/osu.ElasticIndexer/SoloScoreIndexer.cs
+++ b/osu.ElasticIndexer/SoloScoreIndexer.cs
@@ -31,10 +31,10 @@ namespace osu.ElasticIndexer
 
                 checkSchema();
 
-                redis.AddActiveSchema(AppSettings.Schema);
+                redis.AddActiveSchema(metadata.Name);
 
                 if (string.IsNullOrEmpty(redis.GetCurrentSchema()))
-                    redis.SetCurrentSchema(AppSettings.Schema);
+                    redis.SetCurrentSchema(metadata.Name);
 
                 using (new Timer(_ => checkSchema(), null, TimeSpan.Zero, TimeSpan.FromSeconds(5)))
                     new IndexQueueProcessor(metadata.Name, elasticClient, Stop).Run(cts.Token);

--- a/osu.ElasticIndexer/SoloScoreIndexer.cs
+++ b/osu.ElasticIndexer/SoloScoreIndexer.cs
@@ -61,11 +61,11 @@ namespace osu.ElasticIndexer
                     return;
 
                 // schema has changed to the current one
-                if (previousSchema != schema && schema == $"{elasticClient.AliasName}_{AppSettings.Schema}")
+                if (previousSchema != schema && schema == $"{AppSettings.AliasName}_{AppSettings.Schema}")
                 {
                     Console.WriteLine(ConsoleColor.Yellow, $"Schema switched to current: {schema}");
                     previousSchema = schema;
-                    elasticClient.UpdateAlias(elasticClient.AliasName, indexName);
+                    elasticClient.UpdateAlias(AppSettings.AliasName, indexName);
                     return;
                 }
 

--- a/osu.ElasticIndexer/SoloScoreIndexer.cs
+++ b/osu.ElasticIndexer/SoloScoreIndexer.cs
@@ -27,7 +27,7 @@ namespace osu.ElasticIndexer
         {
             using (cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
-                metadata = elasticClient.FindOrCreateIndex(elasticClient.AliasName);
+                metadata = elasticClient.FindOrCreateIndex(AppSettings.Schema);
 
                 checkSchema();
 
@@ -61,7 +61,7 @@ namespace osu.ElasticIndexer
                     return;
 
                 // schema has changed to the current one
-                if (previousSchema != schema && schema == AppSettings.Schema)
+                if (previousSchema != schema && schema == $"{elasticClient.AliasName}_{AppSettings.Schema}")
                 {
                     Console.WriteLine(ConsoleColor.Yellow, $"Schema switched to current: {schema}");
                     previousSchema = schema;

--- a/osu.ElasticIndexer/UnrunnableProcessor.cs
+++ b/osu.ElasticIndexer/UnrunnableProcessor.cs
@@ -8,10 +8,8 @@ namespace osu.ElasticIndexer
 {
     public class UnrunnableProcessor : QueueProcessor<ScoreQueueItem>
     {
-        private static readonly string queue_name = $"score-index-{AppSettings.Schema}";
-
         internal UnrunnableProcessor()
-            : base(new QueueConfiguration { InputQueueName = queue_name })
+            : base(new QueueConfiguration { InputQueueName = $"{AppSettings.AliasName}_{AppSettings.Schema}" })
         {
             if (string.IsNullOrEmpty(AppSettings.Schema))
                 throw new MissingSchemaException();


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-elastic-indexer/pull/151

This simplifies the naming of things related to ES indexing, by naming the indices after the schema versions.

```bash

root@path-to-ranking:~/repos/osu-elastic-indexer/osu.ElasticIndexer# SCHEMA=wang dotnet run queue watch
WARNING: No current schema set, will set new schema as current
Running queue with schema version scores_wang

Creating new index `scores_wang`.
Schema switched to current: scores_wang
Updating `scores` alias to `scores_wang`...
Starting queue processing (Backlog of 0)..
stats: queue:0 inflight:0 dequeued:0 processed:0 errors:0
stats: queue:0 inflight:0 dequeued:0 processed:0 errors:0
^CShutting down..
Bye!
stats: queue:0 inflight:0 dequeued:0 processed:0 errors:0
root@path-to-ranking:~/repos/osu-elastic-indexer/osu.ElasticIndexer# dotnet run index list
# Redis tracking

Active schemas: scores_wang
Current schema: scores_wang

# Elasticsearch indices (1)

scores_wang (454b)
- aliases: scores
- status: open
- docs: 0 (0 deleted)


root@path-to-ranking:~/repos/osu-elastic-indexer/osu.ElasticIndexer# SCHEMA=wang-newer dotnet run queue watch
WARNING: Starting processing for schema version scores_wang-newer which is not current (current schema is scores_wang)
Running queue with schema version scores_wang-newer

Creating new index `scores_wang-newer`.
Starting queue processing (Backlog of 0)..
stats: queue:0 inflight:0 dequeued:0 processed:0 errors:0
^CShutting down..
Bye!

root@path-to-ranking:~/repos/osu-elastic-indexer/osu.ElasticIndexer# dotnet run index alias wang-newer
Updating `scores` alias to `scores_wang-newer`...

root@path-to-ranking:~/repos/osu-elastic-indexer/osu.ElasticIndexer# dotnet run index list
# Redis tracking

Active schemas: scores_wang-newer,scores_wang
Current schema: scores_wang-newer

# Elasticsearch indices (2)

scores_wang (454b)
- aliases:
- status: open
- docs: 0 (0 deleted)

scores_wang-newer (454b)
- aliases: scores
- status: open
- docs: 0 (0 deleted)
```