### PR TITLE
Update schema in line with performance testing

### DIFF
--- a/osu.ElasticIndexer/Score.cs
+++ b/osu.ElasticIndexer/Score.cs
@@ -49,12 +49,6 @@ namespace osu.ElasticIndexer
         [Keyword]
         public int ruleset_id { get; set; }
 
-        [Date(Format = "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss")]
-        public DateTimeOffset created_at { get; set; }
-
-        [Date(Format = "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss")]
-        public DateTimeOffset updated_at { get; set; }
-
         [JsonIgnore]
         [Ignore]
         public string data
@@ -63,17 +57,9 @@ namespace osu.ElasticIndexer
         }
 
         [Computed]
-        [Keyword]
-        public int? build_id => scoreData.BuildID;
-
-        [Computed]
         [Boolean]
         [JsonIgnore]
         public bool convert => ruleset_id != playmode;
-
-        [Computed]
-        [Boolean]
-        public bool passed => scoreData.Passed;
 
         [Ignore]
         public int playmode { get; set; }
@@ -107,14 +93,6 @@ namespace osu.ElasticIndexer
         public int user_warnings { get; set; }
 
         [Computed]
-        [Date(Format = "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss")]
-        public DateTimeOffset? started_at => scoreData.StartedAt;
-
-        [Computed]
-        [Date(Format = "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss")]
-        public DateTimeOffset? ended_at => scoreData.EndedAt;
-
-        [Computed]
         [Keyword]
         public List<string> mods => scoreData.Mods.Select(mod => mod.Acronym).ToList();
 
@@ -124,7 +102,7 @@ namespace osu.ElasticIndexer
 
         [Computed]
         [Boolean]
-        public bool is_legacy => build_id == null;
+        public bool is_legacy => scoreData.BuildID == null;
 
         public ScoreData scoreData = new ScoreData();
 

--- a/osu.ElasticIndexer/Score.cs
+++ b/osu.ElasticIndexer/Score.cs
@@ -85,7 +85,11 @@ namespace osu.ElasticIndexer
 
         [Computed]
         [Number(NumberType.Integer)]
-        public int total_score => scoreData.LegacyTotalScore ?? (int)scoreData.TotalScore; // scoreData.TotalScore should never exceed int.MaxValue at the point of storage.
+        public int total_score => (int)scoreData.TotalScore; // scoreData.TotalScore should never exceed int.MaxValue at the point of storage.
+
+        [Computed]
+        [Number(NumberType.Integer)]
+        public int legacy_total_score => scoreData.LegacyTotalScore ?? 0;
 
         [Computed]
         [Number(NumberType.Float)]

--- a/osu.ElasticIndexer/schemas/scores.json
+++ b/osu.ElasticIndexer/schemas/scores.json
@@ -59,6 +59,9 @@
       "total_score": {
         "type": "integer"
       },
+      "legacy_total_score": {
+        "type": "integer"
+      },
       "updated_at": {
         "format": "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss",
         "type": "date"

--- a/osu.ElasticIndexer/schemas/scores.json
+++ b/osu.ElasticIndexer/schemas/scores.json
@@ -11,22 +11,11 @@
       "beatmap_id": {
         "type": "keyword"
       },
-      "build_id": {
-        "type": "keyword"
-      },
       "convert": {
         "type": "boolean"
       },
       "country_code": {
         "type": "keyword"
-      },
-      "created_at": {
-        "format": "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss",
-        "type": "date"
-      },
-      "ended_at": {
-        "format": "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss",
-        "type": "date"
       },
       "id": {
         "type": "long"
@@ -34,14 +23,8 @@
       "is_legacy": {
         "type": "boolean"
       },
-      "max_combo": {
-        "type": "integer"
-      },
       "mods": {
         "type": "keyword"
-      },
-      "passed": {
-        "type": "boolean"
       },
       "pp": {
         "type": "float"
@@ -52,19 +35,11 @@
       "ruleset_id": {
         "type": "keyword"
       },
-      "started_at": {
-        "format": "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss",
-        "type": "date"
-      },
       "total_score": {
         "type": "integer"
       },
       "legacy_total_score": {
         "type": "integer"
-      },
-      "updated_at": {
-        "format": "strict_date_optional_time||epoch_millis||yyyy-MM-dd HH:mm:ss",
-        "type": "date"
       },
       "user_id": {
         "type": "keyword"

--- a/osu.ElasticIndexer/schemas/scores.json
+++ b/osu.ElasticIndexer/schemas/scores.json
@@ -76,8 +76,8 @@
       "number_of_shards": "2",
       "number_of_replicas": "0",
       "sort": {
-        "field": ["is_legacy", "ruleset_id", "beatmap_id", "id"],
-        "order": ["asc", "asc", "asc", "asc"]
+        "field": ["is_legacy", "ruleset_id", "beatmap_id"],
+        "order": ["asc", "asc", "asc"]
       }
     }
   }

--- a/osu.ElasticIndexer/schemas/scores.json
+++ b/osu.ElasticIndexer/schemas/scores.json
@@ -73,8 +73,8 @@
       "number_of_shards": "2",
       "number_of_replicas": "0",
       "sort": {
-        "field": ["is_legacy", "ruleset_id", "beatmap_id", "total_score", "id"],
-        "order": ["asc", "asc", "asc", "desc", "asc"]
+        "field": ["is_legacy", "ruleset_id", "beatmap_id", "id"],
+        "order": ["asc", "asc", "asc", "asc"]
       }
     }
   }


### PR DESCRIPTION
Also

- Removes a lot of elements which aren't being used (and won't be in the foreseeable future) to reduce the overall index size.
- Splits out `legacy_total_score` so we can access both new and old score without maintaining two indices.