### PR TITLE
Stop indexing `ranked = 0` scores

### DIFF
--- a/osu.ElasticIndexer/Commands/Queue/PumpAllScoresCommand.cs
+++ b/osu.ElasticIndexer/Commands/Queue/PumpAllScoresCommand.cs
@@ -66,7 +66,7 @@ namespace osu.ElasticIndexer.Commands.Queue
             using (var mySqlConnection = processor.GetDatabaseConnection())
 
             {
-                var chunks = ElasticModel.Chunk<Score>(mySqlConnection, "preserve = 1", AppSettings.BatchSize, from);
+                var chunks = ElasticModel.Chunk<Score>(mySqlConnection, "preserve = 1 AND ranked = 1", AppSettings.BatchSize, from);
                 Score? last = null;
 
                 foreach (var scores in chunks)

--- a/osu.ElasticIndexer/Score.cs
+++ b/osu.ElasticIndexer/Score.cs
@@ -30,7 +30,7 @@ namespace osu.ElasticIndexer
         [Computed]
         [Ignore]
         [JsonIgnore]
-        public bool ShouldIndex => preserve && user_warnings == 0;
+        public bool ShouldIndex => preserve && ranked && user_warnings == 0;
 
         // Properties ordered in the order they appear in the table.
 
@@ -65,6 +65,8 @@ namespace osu.ElasticIndexer
         public double? pp { get; set; }
 
         public bool preserve { get; set; }
+
+        public bool ranked { get; set; }
 
         [Number(NumberType.Integer)]
         public int total_score { get; set; } // total score should never exceed int.MaxValue at the point of storage.

--- a/osu.ElasticIndexer/Score.cs
+++ b/osu.ElasticIndexer/Score.cs
@@ -64,9 +64,11 @@ namespace osu.ElasticIndexer
         [Number(NumberType.Float)]
         public double? pp { get; set; }
 
-        public bool preserve { get; set; }
+        [Ignore]
+        public bool preserve { get; set; } // used as precondition to decide whether to index.
 
-        public bool ranked { get; set; }
+        [Ignore]
+        public bool ranked { get; set; } // used as precondition to decide whether to index.
 
         [Number(NumberType.Integer)]
         public int total_score { get; set; } // total score should never exceed int.MaxValue at the point of storage.


### PR DESCRIPTION
To fully realise this, after a deploy we will want to completely regenerate the score index.

I've tested this locally to work as described.