### PR TITLE
Adjust type for total score fields

### DIFF
--- a/osu.ElasticIndexer/schemas/scores.json
+++ b/osu.ElasticIndexer/schemas/scores.json
@@ -39,7 +39,7 @@
         "type": "integer"
       },
       "legacy_total_score": {
-        "type": "integer"
+        "type": "long"
       },
       "user_id": {
         "type": "keyword"


### PR DESCRIPTION
Seems working. At least for the index schema creation, no idea if it fixes the query problem ("failed to create query: Value [3552068564] is out of range for an integer").

Resolves #157.